### PR TITLE
Return empty list for resolved dependencies graph in case no dependencies are found #94

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ v0.9.2
 
 - Make os and python version as mandatory input parameters.
 - Do not return duplicates binaries.
+- Return empty list for resolved dependencies graph in case of no dependencies
+  are found #94 https://github.com/nexB/python-inspector/issues/94.
 
 
 v0.9.1

--- a/src/python_inspector/api.py
+++ b/src/python_inspector/api.py
@@ -208,7 +208,7 @@ def resolve_dependencies(
     if not direct_dependencies:
         return Resolution(
             packages=[],
-            resolution={},
+            resolution=[],
             files=files,
         )
 

--- a/tests/data/setup/no-direct-dependencies-setup.py-expected.json
+++ b/tests/data/setup/no-direct-dependencies-setup.py-expected.json
@@ -81,5 +81,5 @@
     }
   ],
   "packages": [],
-  "resolved_dependencies_graph": {}
+  "resolved_dependencies_graph": []
 }


### PR DESCRIPTION
Reference: https://github.com/nexB/python-inspector/issues/94
Signed-off-by: Tushar Goel <tushar.goel.dav@gmail.com>