### PR TITLE
Fix building the documentation

### DIFF
--- a/requirements_builder.ABOUT
+++ b/requirements_builder.ABOUT
@@ -87,6 +87,6 @@ testing =
     pycodestyle
 
 docs =
-    Sphinx >= 3.3.1
+    Sphinx >= 3.3.1,<7.0.0
     sphinx-rtd-theme >= 0.5.0
     doc8 >= 0.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,6 @@ testing =
     pytest-rerunfailures
 
 docs =
-    Sphinx >= 3.3.1
+    Sphinx >= 3.3.1,<7.0.0
     sphinx-rtd-theme >= 0.5.0
     doc8 >= 0.8.1


### PR DESCRIPTION
The support for `Sphinx` version 7 has been implemented in `rdt-themes`, but hasn't yet been released [1]. Currently, the build uses `Sphinx` version 7 which fails with [2].

Use a `Sphinx` version prior to 7 in order to fix that issue.

[1] https://github.com/readthedocs/sphinx_rtd_theme/issues/1463
[2] `UndefinedError("'style' is undefined")`