### PR TITLE
Support Custom Artifactory Repositories for Package Metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ v0.15.1
 
 - Fetch package metadata from private artifactory if specified https://github.com/aboutcode-org/python-inspector/pull/261
 - Add zip file cache validation https://github.com/aboutcode-org/python-inspector/pull/256
+- Support custom Artifactory repositories with filename-based URL matching,
+  VCS URL extraction from project_urls, source artifact metadata extraction,
+  and metadata enrichment from PyPI.org fallback https://github.com/aboutcode-org/python-inspector/pull/258
 
 
 v0.15.0

--- a/src/python_inspector/package_data.py
+++ b/src/python_inspector/package_data.py
@@ -52,30 +52,42 @@ async def get_pypi_data_from_purl(
     if not version:
         raise Exception("Version is not specified in the purl")
 
-    # Todo: address the case where several index URLs are passed
-    if index_urls:
-        # Backward compatibility: If pypi.org is passed as index url, always resolve against it.
-        # When multiple index URLs are supported and the todo above is fixed, then this hack can be removed.
-        if "https://pypi.org/simple" in index_urls:
-            index_url = None
-        else:
-            index_url = index_urls[0]
-    else:
-        index_url = None
-
-    base_path = (
-        index_url.removesuffix("/simple") + "/pypi" if index_url else "https://pypi.org/pypi"
-    )
-
-    api_url = f"{base_path}/{name}/{version}/json"
+    api_urls = []
+    pypi_org_url = f"https://pypi.org/pypi/{name}/{version}/json"
+    for index_url in index_urls or []:
+        if index_url == "https://pypi.org/simple":
+            continue
+        base_path = index_url.removesuffix("/simple") + "/pypi"
+        api_urls.append((base_path, f"{base_path}/{name}/{version}/json"))
+    api_urls.append(("https://pypi.org/pypi", pypi_org_url))
 
     from python_inspector.utils import get_response_async
 
-    response = await get_response_async(api_url)
+    response = None
+    api_url = None
+    base_path = None
+    info = {}
+    for bp, url in api_urls:
+        repo_response = await get_response_async(url)
+        if not repo_response:
+            continue
+
+        if not response:
+            response = repo_response
+            api_url = url
+            base_path = bp
+            info = response.get("info") or {}
+
+        if not info.get("project_urls"):
+            repo_info = repo_response.get("info") or {}
+            info["project_urls"] = repo_info.get("project_urls")
+
+        if info.get("project_urls"):
+            break
+
     if not response:
         return None
 
-    info = response.get("info") or {}
     homepage_url = info.get("home_page")
     project_urls = info.get("project_urls") or {}
     code_view_url = get_pypi_codeview_url(project_urls)

--- a/src/python_inspector/package_data.py
+++ b/src/python_inspector/package_data.py
@@ -91,6 +91,11 @@ async def get_pypi_data_from_purl(
     homepage_url = info.get("home_page")
     project_urls = info.get("project_urls") or {}
     code_view_url = get_pypi_codeview_url(project_urls)
+    vcs_url = None
+    if code_view_url:
+        vcs_url = code_view_url.rstrip("/")
+        if not vcs_url.endswith(".git"):
+            vcs_url = vcs_url + ".git"
     bug_tracking_url = get_pypi_bugtracker_url(project_urls)
     python_version = get_python_version_from_env_tag(python_version=environment.python_version)
     valid_distribution_urls = []
@@ -197,6 +202,7 @@ async def get_pypi_data_from_purl(
             api_data_url=remove_credentials_from_url(api_url),
             bug_tracking_url=bug_tracking_url,
             code_view_url=code_view_url,
+            vcs_url=vcs_url,
             license_expression=info.get("license_expression"),
             declared_license=get_declared_license(info),
             download_url=remove_credentials_from_url(dist_url),

--- a/src/python_inspector/package_data.py
+++ b/src/python_inspector/package_data.py
@@ -10,6 +10,7 @@
 #
 
 import os
+import posixpath
 from urllib.parse import urlparse, urlunparse
 
 from typing import Dict
@@ -145,6 +146,12 @@ async def get_pypi_data_from_purl(
 
         urls_sanitized[url_sanitized] = value
 
+    urls_by_filename = {
+        posixpath.basename(urlparse(e.get("url")).path): e
+        for e in response.get("urls") or []
+        if e.get("url")
+    }
+
     def remove_credentials_from_url(url: str):
         # Parse the URL into its components
         parsed = urlparse(url)
@@ -163,10 +170,12 @@ async def get_pypi_data_from_purl(
     # iterate over the valid distribution urls and return the first
     # one that is matching.
     for dist_url in valid_distribution_urls:
-        if dist_url not in urls_sanitized:
-            continue
-
         url_data = urls_sanitized.get(dist_url)
+        if not url_data:
+            filename = posixpath.basename(urlparse(dist_url).path)
+            url_data = urls_by_filename.get(filename)
+        if not url_data:
+            continue
         digests = url_data.get("digests") or {}
 
         return PackageData(

--- a/src/python_inspector/package_data.py
+++ b/src/python_inspector/package_data.py
@@ -30,6 +30,20 @@ from python_inspector.utils_pypi import Environment
 from python_inspector.utils_pypi import PypiSimpleRepository
 
 
+def get_sdist_from_urls(urls: list) -> Optional[dict]:
+    """Extract source distribution info from PyPI urls array."""
+    for entry in urls or []:
+        if entry.get("packagetype") == "sdist":
+            return {
+                "url": entry.get("url", ""),
+                "sha256": entry.get("digests", {}).get("sha256", ""),
+                "md5": entry.get("digests", {}).get("md5") or entry.get("md5_digest", ""),
+                "size": entry.get("size"),
+                "filename": entry.get("filename", ""),
+            }
+    return None
+
+
 async def get_pypi_data_from_purl(
     purl: str,
     environment: Environment,
@@ -88,6 +102,7 @@ async def get_pypi_data_from_purl(
     if not response:
         return None
 
+    sdist_info = get_sdist_from_urls(response.get("urls", []))
     homepage_url = info.get("home_page")
     project_urls = info.get("project_urls") or {}
     code_view_url = get_pypi_codeview_url(project_urls)
@@ -202,6 +217,7 @@ async def get_pypi_data_from_purl(
             api_data_url=remove_credentials_from_url(api_url),
             bug_tracking_url=bug_tracking_url,
             code_view_url=code_view_url,
+            extra_data={"source_artifact": sdist_info} if sdist_info else {},
             vcs_url=vcs_url,
             license_expression=info.get("license_expression"),
             declared_license=get_declared_license(info),

--- a/tests/data/azure-devops.req-310-expected.json
+++ b/tests/data/azure-devops.req-310-expected.json
@@ -170,7 +170,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz",
+          "sha256": "f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a",
+          "md5": "da75feda644e8f991bf8498bdbfb86a2",
+          "size": 381042,
+          "filename": "azure_core-1.41.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -238,7 +246,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/f9/495982345252dc7a15ac632e038be1f975ca0d2f25abfe8f8d908569141d/azure-devops-7.1.0b4.tar.gz",
+          "sha256": "f04ba939112579f3d530cfecc044a74ef9e9339ba23c9ee1ece248241f07ff85",
+          "md5": "bf401acf6533d4a2dcfd2106ffcbc86a",
+          "size": 1336261,
+          "filename": "azure-devops-7.1.0b4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -300,7 +316,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz",
+          "sha256": "2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657",
+          "md5": "4d2c63e895c8478d135044e86bb3b676",
+          "size": 611359,
+          "filename": "azure_storage_blob-12.29.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -312,12 +336,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -344,15 +368,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -364,13 +388,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -419,14 +451,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-cffi/cffi/issues",
       "code_view_url": "https://github.com/python-cffi/cffi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-cffi/cffi.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+          "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+          "md5": "5e897f6251e614f6bd128a73e81801a4",
+          "size": 523588,
+          "filename": "cffi-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -499,7 +539,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/jawah/charset_normalizer",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/jawah/charset_normalizer.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -508,7 +548,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz",
+          "sha256": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+          "md5": "68805886064d248d2e5205fd11112d85",
+          "size": 144271,
+          "filename": "charset_normalizer-3.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -520,12 +568,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -543,28 +591,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -624,7 +680,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz",
+          "sha256": "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920",
+          "md5": "9121d585e5990ab79d2779ce36d03779",
+          "size": 832984,
+          "filename": "cryptography-48.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -636,12 +700,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "idna",
-      "version": "3.15",
+      "version": "3.16",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
-      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in\nApplications (IDNA)](https://tools.ietf.org/html/rfc5891)\nand [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\nThe latest versions of these standards supplied here provide\nmore comprehensive language coverage and reduce the potential of\nallowing domains with known security vulnerabilities. This library\nis a suitable replacement for the \"encodings.idna\"\nmodule that comes with the Python standard library, but which\nonly supports an older superseded IDNA specification from 2003.\n\nBasic functions are simply executed:\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\n\n## Installation\n\nThis package is available for installation from PyPI via the\ntypical mechanisms, such as:\n\n```bash\n$ python3 -m pip install idna\n```\n\n\n## Usage\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions if necessary:\n\n```pycon\n>>> idna.alabel('\u6d4b\u8bd5')\nb'xn--0zwm56d'\n```\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as *LATIN\nCAPITAL LETTER K* is not allowed (nor are capital letters in general).\nUTS 46 will convert this into lower case prior to applying the IDNA\nconversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> print(idna.decode('xn--knigsgchen-b4a3dun'))\nk\u00f6nigsg\u00e4\u00dfchen\n```\n\n\n## Exceptions\n\nAll errors raised during the conversion following the specification\nshould raise an exception derived from the `idna.IDNAError` base\nclass.\n\nMore specific exceptions that may be generated as `idna.IDNABidiError`\nwhen the error reflects an illegal combination of left-to-right and\nright-to-left characters in a label; `idna.InvalidCodepoint` when\na specific codepoint is an illegal character in an IDN label (i.e.\nINVALID); and `idna.InvalidCodepointContext` when the codepoint is\nillegal based on its position in the string (i.e. it is CONTEXTO or CONTEXTJ\nbut the contextual requirements are not satisfied.)\n\n## Building and Diagnostics\n\nThe IDNA and UTS 46 functionality relies upon pre-calculated lookup\ntables for performance. These tables are derived from computing against\neligibility criteria in the respective standards using the command-line\nscript `tools/idna-data`.\n\nThis tool will fetch relevant codepoint data from the Unicode repository\nand perform the required calculations to identify eligibility. There are\nthree main modes:\n\n* `idna-data make-libdata`. Generates `idnadata.py` and\n  `uts46data.py`, the pre-calculated lookup tables used for IDNA and\n  UTS 46 conversions. Implementers who wish to track this library against\n  a different Unicode version may use this tool to manually generate a\n  different version of the `idnadata.py` and `uts46data.py` files.\n\n* `idna-data make-table`. Generate a table of the IDNA disposition\n  (e.g. PVALID, CONTEXTJ, CONTEXTO) in the format found in Appendix\n  B.1 of RFC 5892 and the pre-computed tables published by [IANA](https://www.iana.org/).\n\n* `idna-data U+0061`. Prints debugging output on the various\n  properties associated with an individual Unicode codepoint (in this\n  case, U+0061), that are used to assess the IDNA and UTS 46 status of a\n  codepoint. This is helpful in debugging or analysis.\n\nThe tool accepts a number of arguments, described using `idna-data -h`.\nMost notably, the `--version` argument allows the specification\nof the version of Unicode to be used in computing the table data. For\nexample, `idna-data --version 9.0.0 make-libdata` will generate\nlibrary data against Unicode 9.0.0.\n\n\n## Additional Notes\n\n* **Packages**. The latest tagged release version is published in the\n  [Python Package Index](https://pypi.org/project/idna/).\n\n* **Version support**. This library supports Python 3.8 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, many of which strive for broad compatibility with older\n  Python versions, there is no rush to remove older interpreter support.\n  Support for older versions are likely to be removed from new releases\n  as automated tests can no longer easily be run, i.e. once the Python\n  version is officially end-of-life.\n\n* **Testing**. The library has a test suite based on each rule of the\n  IDNA specification, as well as tests that are provided as part of the\n  Unicode Technical Standard 46, [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Transitional processing**. Unicode 16.0.0 removed transitional\n  processing so the `transitional` argument for the encode() method\n  no longer has any effect and will be removed at a later date.",
-      "release_date": "2026-05-12T22:45:55",
+      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in Applications\n(IDNA)](https://tools.ietf.org/html/rfc5891) and [Unicode IDNA\nCompatibility Processing](https://unicode.org/reports/tr46/). It\nsupersedes the standard library's `encodings.idna`, which only\nimplements the 2003 specification, offering broader script coverage and\nlimiting domains with known security vulnerabilities.\n\n## Usage\n\nPackage may be installed from [PyPI](https://pypi.org/project/idna/) via\nthe typical methods (e.g. `python3 -m pip install idna`)\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions for specialized use cases.\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as capital letters\nare not allowed. UTS 46 will convert this into lower case prior to applying\nthe IDNA conversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> idna.decode('xn--knigsgchen-b4a3dun')\n'k\u00f6nigsg\u00e4\u00dfchen'\n```\n\n\n## Exceptions\n\nAll errors raised during conversion derive from the `idna.IDNAError`\nbase class. The more specific exceptions are:\n\n* `idna.IDNABidiError` \u2014 raised when a label contains an illegal\n  combination of left-to-right and right-to-left characters.\n* `idna.InvalidCodepoint` \u2014 raised when a label contains a codepoint\n  that is INVALID for IDNA.\n* `idna.InvalidCodepointContext` \u2014 raised when a CONTEXTO or CONTEXTJ\n  codepoint appears in a position whose contextual requirements are\n  not satisfied.\n\n\n## Command-line tool\n\nThe package supports command-line usage to convert domain names\nbetween their Unicode and ASCII-compatible forms. It can be run either\nas a module (`python3 -m idna`) or, once installed (such as with `uv\ntool` or `pipx`), via the `idna` script:\n\n```bash\n$ uv tool install idna\n$ idna xn--e1afmkfd.xn--p1ai\n\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\n$ idna \u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\nxn--e1afmkfd.xn--p1ai\n```\n\nWith no mode flag the direction is chosen automatically: inputs\ncontaining an `xn--` label are decoded, anything else is encoded. Pass\n`-e`/`--encode` or `-d`/`--decode` to force a specific direction.\n\nMultiple domains may be supplied at once, either as positional arguments\nor by piping one domain per line on standard input. When more than\none domain is supplied without explicitly asking to encode or decode,\nthe direction is picked from the first input and that mode is applied\nto every remaining input. Use `-e`/`--encode` or `-d`/`--decode` to\noverride the heuristic if the first input is ambiguous.\n\nUTS #46 mapping is applied by default, which lets the tool accept\ninputs that aren't strictly valid IDNA 2008 by normalising them first:\n\n```bash\n$ idna \u03a0\u0391\u03a1\u0386\u0394\u0395\u0399\u0393\u039c\u0391.\u0395\u039b\nxn--hxajbheg2az3al.xn--qxam\n```\n\nPass `--strict` to disable UTS #46 and apply IDNA 2008 rules verbatim;\nthe same input will then be rejected.\n\nConversion failures are reported on stderr together with the\noffending input; processing continues with the remaining domains and\nthe tool exits with a non-zero status if any conversion failed.\n\n\n## Additional Notes\n\n* **Version support**. This library supports Python 3.9 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, we strive to support all versions of Python that are\n  not beyond end-of-life.\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Regenerating lookup tables**. The IDNA and UTS 46 functionality\n  relies upon pre-calculated lookup tables, generated using the\n  `idna-data` script in [`tools/`](tools/README.md).",
+      "release_date": "2026-05-22T00:16:16",
       "parties": [
         {
           "type": "person",
@@ -664,7 +728,6 @@
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
@@ -673,28 +736,36 @@
         "Topic :: Utilities"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-      "size": 72340,
+      "download_url": "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl",
+      "size": 74165,
       "sha1": null,
-      "md5": "a1e6be4b7c837089c035bd5aec4feeca",
-      "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+      "md5": "6866dc1362986ffa0c4eee4c16a059cd",
+      "sha256": "cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/kjd/idna",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/kjd/idna.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz",
+          "sha256": "d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d",
+          "md5": "7dfcadedaaa152963f6e6ab0fcbe5aab",
+          "size": 203770,
+          "filename": "idna-3.16.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/idna/3.15/json",
+      "api_data_url": "https://pypi.org/pypi/idna/3.16/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/idna@3.15"
+      "purl": "pkg:pypi/idna@3.16"
     },
     {
       "type": "pypi",
@@ -754,7 +825,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz",
+          "sha256": "4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6",
+          "md5": "5ce182fd7f6152cda19ec605b6740687",
+          "size": 29705,
+          "filename": "isodate-0.7.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -814,7 +893,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip",
+          "sha256": "6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9",
+          "md5": "3079617446a011d4fc0098687609671e",
+          "size": 175332,
+          "filename": "msrest-0.7.1.zip"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -887,7 +974,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz",
+          "sha256": "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+          "md5": "856bc51662afb26ac58b1d7742606b2e",
+          "size": 185918,
+          "filename": "oauthlib-3.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -946,7 +1041,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz",
+          "sha256": "600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+          "md5": "56f3a0a82595b0cb04976cc0d3271a27",
+          "size": 103492,
+          "filename": "pycparser-3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1012,7 +1115,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz",
+          "sha256": "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9",
+          "md5": "713dc7856f9ff625d75335c10d332a1b",
+          "size": 55650,
+          "filename": "requests-oauthlib-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1076,7 +1187,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1088,7 +1199,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz",
+          "sha256": "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed",
+          "md5": "611e438d0803e962500225f9807a475e",
+          "size": 142856,
+          "filename": "requests-2.34.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1158,7 +1277,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz",
+          "sha256": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "md5": "079e529d0b271647f3ec2720aee8fc65",
+          "size": 109391,
+          "filename": "typing_extensions-4.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1227,14 +1354,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz",
+          "sha256": "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+          "md5": "e79707b798a66c8165c9c441440f4e80",
+          "size": 433602,
+          "filename": "urllib3-2.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1267,7 +1402,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -1281,7 +1416,7 @@
       "dependencies": []
     },
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
@@ -1291,7 +1426,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/idna@3.15",
+      "package": "pkg:pypi/idna@3.16",
       "dependencies": []
     },
     {
@@ -1302,7 +1437,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.41.0",
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.34.2"
@@ -1326,9 +1461,9 @@
     {
       "package": "pkg:pypi/requests@2.34.2",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/charset-normalizer@3.4.7",
-        "pkg:pypi/idna@3.15",
+        "pkg:pypi/idna@3.16",
         "pkg:pypi/urllib3@2.7.0"
       ]
     },

--- a/tests/data/azure-devops.req-312-expected.json
+++ b/tests/data/azure-devops.req-312-expected.json
@@ -170,7 +170,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz",
+          "sha256": "f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a",
+          "md5": "da75feda644e8f991bf8498bdbfb86a2",
+          "size": 381042,
+          "filename": "azure_core-1.41.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -238,7 +246,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/f9/495982345252dc7a15ac632e038be1f975ca0d2f25abfe8f8d908569141d/azure-devops-7.1.0b4.tar.gz",
+          "sha256": "f04ba939112579f3d530cfecc044a74ef9e9339ba23c9ee1ece248241f07ff85",
+          "md5": "bf401acf6533d4a2dcfd2106ffcbc86a",
+          "size": 1336261,
+          "filename": "azure-devops-7.1.0b4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -300,7 +316,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz",
+          "sha256": "2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657",
+          "md5": "4d2c63e895c8478d135044e86bb3b676",
+          "size": 611359,
+          "filename": "azure_storage_blob-12.29.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -312,12 +336,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -344,15 +368,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -364,13 +388,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -419,14 +451,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-cffi/cffi/issues",
       "code_view_url": "https://github.com/python-cffi/cffi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-cffi/cffi.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+          "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+          "md5": "5e897f6251e614f6bd128a73e81801a4",
+          "size": 523588,
+          "filename": "cffi-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -499,7 +539,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/jawah/charset_normalizer",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/jawah/charset_normalizer.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -508,7 +548,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz",
+          "sha256": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+          "md5": "68805886064d248d2e5205fd11112d85",
+          "size": 144271,
+          "filename": "charset_normalizer-3.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -520,12 +568,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -543,28 +591,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -624,7 +680,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz",
+          "sha256": "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920",
+          "md5": "9121d585e5990ab79d2779ce36d03779",
+          "size": 832984,
+          "filename": "cryptography-48.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -636,12 +700,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "idna",
-      "version": "3.15",
+      "version": "3.16",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
-      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in\nApplications (IDNA)](https://tools.ietf.org/html/rfc5891)\nand [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\nThe latest versions of these standards supplied here provide\nmore comprehensive language coverage and reduce the potential of\nallowing domains with known security vulnerabilities. This library\nis a suitable replacement for the \"encodings.idna\"\nmodule that comes with the Python standard library, but which\nonly supports an older superseded IDNA specification from 2003.\n\nBasic functions are simply executed:\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\n\n## Installation\n\nThis package is available for installation from PyPI via the\ntypical mechanisms, such as:\n\n```bash\n$ python3 -m pip install idna\n```\n\n\n## Usage\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions if necessary:\n\n```pycon\n>>> idna.alabel('\u6d4b\u8bd5')\nb'xn--0zwm56d'\n```\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as *LATIN\nCAPITAL LETTER K* is not allowed (nor are capital letters in general).\nUTS 46 will convert this into lower case prior to applying the IDNA\nconversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> print(idna.decode('xn--knigsgchen-b4a3dun'))\nk\u00f6nigsg\u00e4\u00dfchen\n```\n\n\n## Exceptions\n\nAll errors raised during the conversion following the specification\nshould raise an exception derived from the `idna.IDNAError` base\nclass.\n\nMore specific exceptions that may be generated as `idna.IDNABidiError`\nwhen the error reflects an illegal combination of left-to-right and\nright-to-left characters in a label; `idna.InvalidCodepoint` when\na specific codepoint is an illegal character in an IDN label (i.e.\nINVALID); and `idna.InvalidCodepointContext` when the codepoint is\nillegal based on its position in the string (i.e. it is CONTEXTO or CONTEXTJ\nbut the contextual requirements are not satisfied.)\n\n## Building and Diagnostics\n\nThe IDNA and UTS 46 functionality relies upon pre-calculated lookup\ntables for performance. These tables are derived from computing against\neligibility criteria in the respective standards using the command-line\nscript `tools/idna-data`.\n\nThis tool will fetch relevant codepoint data from the Unicode repository\nand perform the required calculations to identify eligibility. There are\nthree main modes:\n\n* `idna-data make-libdata`. Generates `idnadata.py` and\n  `uts46data.py`, the pre-calculated lookup tables used for IDNA and\n  UTS 46 conversions. Implementers who wish to track this library against\n  a different Unicode version may use this tool to manually generate a\n  different version of the `idnadata.py` and `uts46data.py` files.\n\n* `idna-data make-table`. Generate a table of the IDNA disposition\n  (e.g. PVALID, CONTEXTJ, CONTEXTO) in the format found in Appendix\n  B.1 of RFC 5892 and the pre-computed tables published by [IANA](https://www.iana.org/).\n\n* `idna-data U+0061`. Prints debugging output on the various\n  properties associated with an individual Unicode codepoint (in this\n  case, U+0061), that are used to assess the IDNA and UTS 46 status of a\n  codepoint. This is helpful in debugging or analysis.\n\nThe tool accepts a number of arguments, described using `idna-data -h`.\nMost notably, the `--version` argument allows the specification\nof the version of Unicode to be used in computing the table data. For\nexample, `idna-data --version 9.0.0 make-libdata` will generate\nlibrary data against Unicode 9.0.0.\n\n\n## Additional Notes\n\n* **Packages**. The latest tagged release version is published in the\n  [Python Package Index](https://pypi.org/project/idna/).\n\n* **Version support**. This library supports Python 3.8 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, many of which strive for broad compatibility with older\n  Python versions, there is no rush to remove older interpreter support.\n  Support for older versions are likely to be removed from new releases\n  as automated tests can no longer easily be run, i.e. once the Python\n  version is officially end-of-life.\n\n* **Testing**. The library has a test suite based on each rule of the\n  IDNA specification, as well as tests that are provided as part of the\n  Unicode Technical Standard 46, [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Transitional processing**. Unicode 16.0.0 removed transitional\n  processing so the `transitional` argument for the encode() method\n  no longer has any effect and will be removed at a later date.",
-      "release_date": "2026-05-12T22:45:55",
+      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in Applications\n(IDNA)](https://tools.ietf.org/html/rfc5891) and [Unicode IDNA\nCompatibility Processing](https://unicode.org/reports/tr46/). It\nsupersedes the standard library's `encodings.idna`, which only\nimplements the 2003 specification, offering broader script coverage and\nlimiting domains with known security vulnerabilities.\n\n## Usage\n\nPackage may be installed from [PyPI](https://pypi.org/project/idna/) via\nthe typical methods (e.g. `python3 -m pip install idna`)\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions for specialized use cases.\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as capital letters\nare not allowed. UTS 46 will convert this into lower case prior to applying\nthe IDNA conversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> idna.decode('xn--knigsgchen-b4a3dun')\n'k\u00f6nigsg\u00e4\u00dfchen'\n```\n\n\n## Exceptions\n\nAll errors raised during conversion derive from the `idna.IDNAError`\nbase class. The more specific exceptions are:\n\n* `idna.IDNABidiError` \u2014 raised when a label contains an illegal\n  combination of left-to-right and right-to-left characters.\n* `idna.InvalidCodepoint` \u2014 raised when a label contains a codepoint\n  that is INVALID for IDNA.\n* `idna.InvalidCodepointContext` \u2014 raised when a CONTEXTO or CONTEXTJ\n  codepoint appears in a position whose contextual requirements are\n  not satisfied.\n\n\n## Command-line tool\n\nThe package supports command-line usage to convert domain names\nbetween their Unicode and ASCII-compatible forms. It can be run either\nas a module (`python3 -m idna`) or, once installed (such as with `uv\ntool` or `pipx`), via the `idna` script:\n\n```bash\n$ uv tool install idna\n$ idna xn--e1afmkfd.xn--p1ai\n\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\n$ idna \u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\nxn--e1afmkfd.xn--p1ai\n```\n\nWith no mode flag the direction is chosen automatically: inputs\ncontaining an `xn--` label are decoded, anything else is encoded. Pass\n`-e`/`--encode` or `-d`/`--decode` to force a specific direction.\n\nMultiple domains may be supplied at once, either as positional arguments\nor by piping one domain per line on standard input. When more than\none domain is supplied without explicitly asking to encode or decode,\nthe direction is picked from the first input and that mode is applied\nto every remaining input. Use `-e`/`--encode` or `-d`/`--decode` to\noverride the heuristic if the first input is ambiguous.\n\nUTS #46 mapping is applied by default, which lets the tool accept\ninputs that aren't strictly valid IDNA 2008 by normalising them first:\n\n```bash\n$ idna \u03a0\u0391\u03a1\u0386\u0394\u0395\u0399\u0393\u039c\u0391.\u0395\u039b\nxn--hxajbheg2az3al.xn--qxam\n```\n\nPass `--strict` to disable UTS #46 and apply IDNA 2008 rules verbatim;\nthe same input will then be rejected.\n\nConversion failures are reported on stderr together with the\noffending input; processing continues with the remaining domains and\nthe tool exits with a non-zero status if any conversion failed.\n\n\n## Additional Notes\n\n* **Version support**. This library supports Python 3.9 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, we strive to support all versions of Python that are\n  not beyond end-of-life.\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Regenerating lookup tables**. The IDNA and UTS 46 functionality\n  relies upon pre-calculated lookup tables, generated using the\n  `idna-data` script in [`tools/`](tools/README.md).",
+      "release_date": "2026-05-22T00:16:16",
       "parties": [
         {
           "type": "person",
@@ -664,7 +728,6 @@
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
@@ -673,28 +736,36 @@
         "Topic :: Utilities"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-      "size": 72340,
+      "download_url": "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl",
+      "size": 74165,
       "sha1": null,
-      "md5": "a1e6be4b7c837089c035bd5aec4feeca",
-      "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+      "md5": "6866dc1362986ffa0c4eee4c16a059cd",
+      "sha256": "cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/kjd/idna",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/kjd/idna.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz",
+          "sha256": "d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d",
+          "md5": "7dfcadedaaa152963f6e6ab0fcbe5aab",
+          "size": 203770,
+          "filename": "idna-3.16.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/idna/3.15/json",
+      "api_data_url": "https://pypi.org/pypi/idna/3.16/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/idna@3.15"
+      "purl": "pkg:pypi/idna@3.16"
     },
     {
       "type": "pypi",
@@ -754,7 +825,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz",
+          "sha256": "4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6",
+          "md5": "5ce182fd7f6152cda19ec605b6740687",
+          "size": 29705,
+          "filename": "isodate-0.7.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -814,7 +893,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip",
+          "sha256": "6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9",
+          "md5": "3079617446a011d4fc0098687609671e",
+          "size": 175332,
+          "filename": "msrest-0.7.1.zip"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -887,7 +974,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz",
+          "sha256": "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+          "md5": "856bc51662afb26ac58b1d7742606b2e",
+          "size": 185918,
+          "filename": "oauthlib-3.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -946,7 +1041,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz",
+          "sha256": "600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+          "md5": "56f3a0a82595b0cb04976cc0d3271a27",
+          "size": 103492,
+          "filename": "pycparser-3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1012,7 +1115,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz",
+          "sha256": "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9",
+          "md5": "713dc7856f9ff625d75335c10d332a1b",
+          "size": 55650,
+          "filename": "requests-oauthlib-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1076,7 +1187,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1088,7 +1199,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz",
+          "sha256": "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed",
+          "md5": "611e438d0803e962500225f9807a475e",
+          "size": 142856,
+          "filename": "requests-2.34.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1158,7 +1277,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz",
+          "sha256": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "md5": "079e529d0b271647f3ec2720aee8fc65",
+          "size": 109391,
+          "filename": "typing_extensions-4.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1227,14 +1354,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz",
+          "sha256": "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+          "md5": "e79707b798a66c8165c9c441440f4e80",
+          "size": 433602,
+          "filename": "urllib3-2.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1267,7 +1402,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -1281,7 +1416,7 @@
       "dependencies": []
     },
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
@@ -1291,7 +1426,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/idna@3.15",
+      "package": "pkg:pypi/idna@3.16",
       "dependencies": []
     },
     {
@@ -1302,7 +1437,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.41.0",
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.34.2"
@@ -1326,9 +1461,9 @@
     {
       "package": "pkg:pypi/requests@2.34.2",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/charset-normalizer@3.4.7",
-        "pkg:pypi/idna@3.15",
+        "pkg:pypi/idna@3.16",
         "pkg:pypi/urllib3@2.7.0"
       ]
     },

--- a/tests/data/azure-devops.req-313-expected.json
+++ b/tests/data/azure-devops.req-313-expected.json
@@ -170,7 +170,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz",
+          "sha256": "f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a",
+          "md5": "da75feda644e8f991bf8498bdbfb86a2",
+          "size": 381042,
+          "filename": "azure_core-1.41.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -238,7 +246,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/f9/495982345252dc7a15ac632e038be1f975ca0d2f25abfe8f8d908569141d/azure-devops-7.1.0b4.tar.gz",
+          "sha256": "f04ba939112579f3d530cfecc044a74ef9e9339ba23c9ee1ece248241f07ff85",
+          "md5": "bf401acf6533d4a2dcfd2106ffcbc86a",
+          "size": 1336261,
+          "filename": "azure-devops-7.1.0b4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -300,7 +316,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz",
+          "sha256": "2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657",
+          "md5": "4d2c63e895c8478d135044e86bb3b676",
+          "size": 611359,
+          "filename": "azure_storage_blob-12.29.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -312,12 +336,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -344,15 +368,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -364,13 +388,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -419,14 +451,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-cffi/cffi/issues",
       "code_view_url": "https://github.com/python-cffi/cffi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-cffi/cffi.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+          "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+          "md5": "5e897f6251e614f6bd128a73e81801a4",
+          "size": 523588,
+          "filename": "cffi-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -499,7 +539,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/jawah/charset_normalizer",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/jawah/charset_normalizer.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -508,7 +548,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz",
+          "sha256": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+          "md5": "68805886064d248d2e5205fd11112d85",
+          "size": 144271,
+          "filename": "charset_normalizer-3.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -520,12 +568,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -543,28 +591,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -624,7 +680,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz",
+          "sha256": "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920",
+          "md5": "9121d585e5990ab79d2779ce36d03779",
+          "size": 832984,
+          "filename": "cryptography-48.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -636,12 +700,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "idna",
-      "version": "3.15",
+      "version": "3.16",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
-      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in\nApplications (IDNA)](https://tools.ietf.org/html/rfc5891)\nand [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\nThe latest versions of these standards supplied here provide\nmore comprehensive language coverage and reduce the potential of\nallowing domains with known security vulnerabilities. This library\nis a suitable replacement for the \"encodings.idna\"\nmodule that comes with the Python standard library, but which\nonly supports an older superseded IDNA specification from 2003.\n\nBasic functions are simply executed:\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\n\n## Installation\n\nThis package is available for installation from PyPI via the\ntypical mechanisms, such as:\n\n```bash\n$ python3 -m pip install idna\n```\n\n\n## Usage\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions if necessary:\n\n```pycon\n>>> idna.alabel('\u6d4b\u8bd5')\nb'xn--0zwm56d'\n```\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as *LATIN\nCAPITAL LETTER K* is not allowed (nor are capital letters in general).\nUTS 46 will convert this into lower case prior to applying the IDNA\nconversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> print(idna.decode('xn--knigsgchen-b4a3dun'))\nk\u00f6nigsg\u00e4\u00dfchen\n```\n\n\n## Exceptions\n\nAll errors raised during the conversion following the specification\nshould raise an exception derived from the `idna.IDNAError` base\nclass.\n\nMore specific exceptions that may be generated as `idna.IDNABidiError`\nwhen the error reflects an illegal combination of left-to-right and\nright-to-left characters in a label; `idna.InvalidCodepoint` when\na specific codepoint is an illegal character in an IDN label (i.e.\nINVALID); and `idna.InvalidCodepointContext` when the codepoint is\nillegal based on its position in the string (i.e. it is CONTEXTO or CONTEXTJ\nbut the contextual requirements are not satisfied.)\n\n## Building and Diagnostics\n\nThe IDNA and UTS 46 functionality relies upon pre-calculated lookup\ntables for performance. These tables are derived from computing against\neligibility criteria in the respective standards using the command-line\nscript `tools/idna-data`.\n\nThis tool will fetch relevant codepoint data from the Unicode repository\nand perform the required calculations to identify eligibility. There are\nthree main modes:\n\n* `idna-data make-libdata`. Generates `idnadata.py` and\n  `uts46data.py`, the pre-calculated lookup tables used for IDNA and\n  UTS 46 conversions. Implementers who wish to track this library against\n  a different Unicode version may use this tool to manually generate a\n  different version of the `idnadata.py` and `uts46data.py` files.\n\n* `idna-data make-table`. Generate a table of the IDNA disposition\n  (e.g. PVALID, CONTEXTJ, CONTEXTO) in the format found in Appendix\n  B.1 of RFC 5892 and the pre-computed tables published by [IANA](https://www.iana.org/).\n\n* `idna-data U+0061`. Prints debugging output on the various\n  properties associated with an individual Unicode codepoint (in this\n  case, U+0061), that are used to assess the IDNA and UTS 46 status of a\n  codepoint. This is helpful in debugging or analysis.\n\nThe tool accepts a number of arguments, described using `idna-data -h`.\nMost notably, the `--version` argument allows the specification\nof the version of Unicode to be used in computing the table data. For\nexample, `idna-data --version 9.0.0 make-libdata` will generate\nlibrary data against Unicode 9.0.0.\n\n\n## Additional Notes\n\n* **Packages**. The latest tagged release version is published in the\n  [Python Package Index](https://pypi.org/project/idna/).\n\n* **Version support**. This library supports Python 3.8 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, many of which strive for broad compatibility with older\n  Python versions, there is no rush to remove older interpreter support.\n  Support for older versions are likely to be removed from new releases\n  as automated tests can no longer easily be run, i.e. once the Python\n  version is officially end-of-life.\n\n* **Testing**. The library has a test suite based on each rule of the\n  IDNA specification, as well as tests that are provided as part of the\n  Unicode Technical Standard 46, [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Transitional processing**. Unicode 16.0.0 removed transitional\n  processing so the `transitional` argument for the encode() method\n  no longer has any effect and will be removed at a later date.",
-      "release_date": "2026-05-12T22:45:55",
+      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in Applications\n(IDNA)](https://tools.ietf.org/html/rfc5891) and [Unicode IDNA\nCompatibility Processing](https://unicode.org/reports/tr46/). It\nsupersedes the standard library's `encodings.idna`, which only\nimplements the 2003 specification, offering broader script coverage and\nlimiting domains with known security vulnerabilities.\n\n## Usage\n\nPackage may be installed from [PyPI](https://pypi.org/project/idna/) via\nthe typical methods (e.g. `python3 -m pip install idna`)\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions for specialized use cases.\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as capital letters\nare not allowed. UTS 46 will convert this into lower case prior to applying\nthe IDNA conversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> idna.decode('xn--knigsgchen-b4a3dun')\n'k\u00f6nigsg\u00e4\u00dfchen'\n```\n\n\n## Exceptions\n\nAll errors raised during conversion derive from the `idna.IDNAError`\nbase class. The more specific exceptions are:\n\n* `idna.IDNABidiError` \u2014 raised when a label contains an illegal\n  combination of left-to-right and right-to-left characters.\n* `idna.InvalidCodepoint` \u2014 raised when a label contains a codepoint\n  that is INVALID for IDNA.\n* `idna.InvalidCodepointContext` \u2014 raised when a CONTEXTO or CONTEXTJ\n  codepoint appears in a position whose contextual requirements are\n  not satisfied.\n\n\n## Command-line tool\n\nThe package supports command-line usage to convert domain names\nbetween their Unicode and ASCII-compatible forms. It can be run either\nas a module (`python3 -m idna`) or, once installed (such as with `uv\ntool` or `pipx`), via the `idna` script:\n\n```bash\n$ uv tool install idna\n$ idna xn--e1afmkfd.xn--p1ai\n\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\n$ idna \u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\nxn--e1afmkfd.xn--p1ai\n```\n\nWith no mode flag the direction is chosen automatically: inputs\ncontaining an `xn--` label are decoded, anything else is encoded. Pass\n`-e`/`--encode` or `-d`/`--decode` to force a specific direction.\n\nMultiple domains may be supplied at once, either as positional arguments\nor by piping one domain per line on standard input. When more than\none domain is supplied without explicitly asking to encode or decode,\nthe direction is picked from the first input and that mode is applied\nto every remaining input. Use `-e`/`--encode` or `-d`/`--decode` to\noverride the heuristic if the first input is ambiguous.\n\nUTS #46 mapping is applied by default, which lets the tool accept\ninputs that aren't strictly valid IDNA 2008 by normalising them first:\n\n```bash\n$ idna \u03a0\u0391\u03a1\u0386\u0394\u0395\u0399\u0393\u039c\u0391.\u0395\u039b\nxn--hxajbheg2az3al.xn--qxam\n```\n\nPass `--strict` to disable UTS #46 and apply IDNA 2008 rules verbatim;\nthe same input will then be rejected.\n\nConversion failures are reported on stderr together with the\noffending input; processing continues with the remaining domains and\nthe tool exits with a non-zero status if any conversion failed.\n\n\n## Additional Notes\n\n* **Version support**. This library supports Python 3.9 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, we strive to support all versions of Python that are\n  not beyond end-of-life.\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Regenerating lookup tables**. The IDNA and UTS 46 functionality\n  relies upon pre-calculated lookup tables, generated using the\n  `idna-data` script in [`tools/`](tools/README.md).",
+      "release_date": "2026-05-22T00:16:16",
       "parties": [
         {
           "type": "person",
@@ -664,7 +728,6 @@
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
@@ -673,28 +736,36 @@
         "Topic :: Utilities"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-      "size": 72340,
+      "download_url": "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl",
+      "size": 74165,
       "sha1": null,
-      "md5": "a1e6be4b7c837089c035bd5aec4feeca",
-      "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+      "md5": "6866dc1362986ffa0c4eee4c16a059cd",
+      "sha256": "cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/kjd/idna",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/kjd/idna.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz",
+          "sha256": "d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d",
+          "md5": "7dfcadedaaa152963f6e6ab0fcbe5aab",
+          "size": 203770,
+          "filename": "idna-3.16.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/idna/3.15/json",
+      "api_data_url": "https://pypi.org/pypi/idna/3.16/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/idna@3.15"
+      "purl": "pkg:pypi/idna@3.16"
     },
     {
       "type": "pypi",
@@ -754,7 +825,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz",
+          "sha256": "4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6",
+          "md5": "5ce182fd7f6152cda19ec605b6740687",
+          "size": 29705,
+          "filename": "isodate-0.7.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -814,7 +893,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip",
+          "sha256": "6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9",
+          "md5": "3079617446a011d4fc0098687609671e",
+          "size": 175332,
+          "filename": "msrest-0.7.1.zip"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -887,7 +974,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz",
+          "sha256": "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+          "md5": "856bc51662afb26ac58b1d7742606b2e",
+          "size": 185918,
+          "filename": "oauthlib-3.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -946,7 +1041,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz",
+          "sha256": "600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+          "md5": "56f3a0a82595b0cb04976cc0d3271a27",
+          "size": 103492,
+          "filename": "pycparser-3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1012,7 +1115,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz",
+          "sha256": "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9",
+          "md5": "713dc7856f9ff625d75335c10d332a1b",
+          "size": 55650,
+          "filename": "requests-oauthlib-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1076,7 +1187,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1088,7 +1199,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz",
+          "sha256": "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed",
+          "md5": "611e438d0803e962500225f9807a475e",
+          "size": 142856,
+          "filename": "requests-2.34.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1158,7 +1277,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz",
+          "sha256": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "md5": "079e529d0b271647f3ec2720aee8fc65",
+          "size": 109391,
+          "filename": "typing_extensions-4.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1227,14 +1354,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz",
+          "sha256": "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+          "md5": "e79707b798a66c8165c9c441440f4e80",
+          "size": 433602,
+          "filename": "urllib3-2.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1267,7 +1402,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -1281,7 +1416,7 @@
       "dependencies": []
     },
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
@@ -1291,7 +1426,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/idna@3.15",
+      "package": "pkg:pypi/idna@3.16",
       "dependencies": []
     },
     {
@@ -1302,7 +1437,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.41.0",
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.34.2"
@@ -1326,9 +1461,9 @@
     {
       "package": "pkg:pypi/requests@2.34.2",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/charset-normalizer@3.4.7",
-        "pkg:pypi/idna@3.15",
+        "pkg:pypi/idna@3.16",
         "pkg:pypi/urllib3@2.7.0"
       ]
     },

--- a/tests/data/azure-devops.req-314-expected.json
+++ b/tests/data/azure-devops.req-314-expected.json
@@ -170,7 +170,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz",
+          "sha256": "f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a",
+          "md5": "da75feda644e8f991bf8498bdbfb86a2",
+          "size": 381042,
+          "filename": "azure_core-1.41.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -238,7 +246,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/f9/495982345252dc7a15ac632e038be1f975ca0d2f25abfe8f8d908569141d/azure-devops-7.1.0b4.tar.gz",
+          "sha256": "f04ba939112579f3d530cfecc044a74ef9e9339ba23c9ee1ece248241f07ff85",
+          "md5": "bf401acf6533d4a2dcfd2106ffcbc86a",
+          "size": 1336261,
+          "filename": "azure-devops-7.1.0b4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -300,7 +316,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz",
+          "sha256": "2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657",
+          "md5": "4d2c63e895c8478d135044e86bb3b676",
+          "size": 611359,
+          "filename": "azure_storage_blob-12.29.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -312,12 +336,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -344,15 +368,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -364,13 +388,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -419,14 +451,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-cffi/cffi/issues",
       "code_view_url": "https://github.com/python-cffi/cffi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-cffi/cffi.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+          "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+          "md5": "5e897f6251e614f6bd128a73e81801a4",
+          "size": 523588,
+          "filename": "cffi-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -499,7 +539,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/jawah/charset_normalizer",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/jawah/charset_normalizer.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -508,7 +548,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz",
+          "sha256": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+          "md5": "68805886064d248d2e5205fd11112d85",
+          "size": 144271,
+          "filename": "charset_normalizer-3.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -520,12 +568,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -543,28 +591,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -624,7 +680,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz",
+          "sha256": "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920",
+          "md5": "9121d585e5990ab79d2779ce36d03779",
+          "size": 832984,
+          "filename": "cryptography-48.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -636,12 +700,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "idna",
-      "version": "3.15",
+      "version": "3.16",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
-      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in\nApplications (IDNA)](https://tools.ietf.org/html/rfc5891)\nand [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\nThe latest versions of these standards supplied here provide\nmore comprehensive language coverage and reduce the potential of\nallowing domains with known security vulnerabilities. This library\nis a suitable replacement for the \"encodings.idna\"\nmodule that comes with the Python standard library, but which\nonly supports an older superseded IDNA specification from 2003.\n\nBasic functions are simply executed:\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\n\n## Installation\n\nThis package is available for installation from PyPI via the\ntypical mechanisms, such as:\n\n```bash\n$ python3 -m pip install idna\n```\n\n\n## Usage\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions if necessary:\n\n```pycon\n>>> idna.alabel('\u6d4b\u8bd5')\nb'xn--0zwm56d'\n```\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as *LATIN\nCAPITAL LETTER K* is not allowed (nor are capital letters in general).\nUTS 46 will convert this into lower case prior to applying the IDNA\nconversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> print(idna.decode('xn--knigsgchen-b4a3dun'))\nk\u00f6nigsg\u00e4\u00dfchen\n```\n\n\n## Exceptions\n\nAll errors raised during the conversion following the specification\nshould raise an exception derived from the `idna.IDNAError` base\nclass.\n\nMore specific exceptions that may be generated as `idna.IDNABidiError`\nwhen the error reflects an illegal combination of left-to-right and\nright-to-left characters in a label; `idna.InvalidCodepoint` when\na specific codepoint is an illegal character in an IDN label (i.e.\nINVALID); and `idna.InvalidCodepointContext` when the codepoint is\nillegal based on its position in the string (i.e. it is CONTEXTO or CONTEXTJ\nbut the contextual requirements are not satisfied.)\n\n## Building and Diagnostics\n\nThe IDNA and UTS 46 functionality relies upon pre-calculated lookup\ntables for performance. These tables are derived from computing against\neligibility criteria in the respective standards using the command-line\nscript `tools/idna-data`.\n\nThis tool will fetch relevant codepoint data from the Unicode repository\nand perform the required calculations to identify eligibility. There are\nthree main modes:\n\n* `idna-data make-libdata`. Generates `idnadata.py` and\n  `uts46data.py`, the pre-calculated lookup tables used for IDNA and\n  UTS 46 conversions. Implementers who wish to track this library against\n  a different Unicode version may use this tool to manually generate a\n  different version of the `idnadata.py` and `uts46data.py` files.\n\n* `idna-data make-table`. Generate a table of the IDNA disposition\n  (e.g. PVALID, CONTEXTJ, CONTEXTO) in the format found in Appendix\n  B.1 of RFC 5892 and the pre-computed tables published by [IANA](https://www.iana.org/).\n\n* `idna-data U+0061`. Prints debugging output on the various\n  properties associated with an individual Unicode codepoint (in this\n  case, U+0061), that are used to assess the IDNA and UTS 46 status of a\n  codepoint. This is helpful in debugging or analysis.\n\nThe tool accepts a number of arguments, described using `idna-data -h`.\nMost notably, the `--version` argument allows the specification\nof the version of Unicode to be used in computing the table data. For\nexample, `idna-data --version 9.0.0 make-libdata` will generate\nlibrary data against Unicode 9.0.0.\n\n\n## Additional Notes\n\n* **Packages**. The latest tagged release version is published in the\n  [Python Package Index](https://pypi.org/project/idna/).\n\n* **Version support**. This library supports Python 3.8 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, many of which strive for broad compatibility with older\n  Python versions, there is no rush to remove older interpreter support.\n  Support for older versions are likely to be removed from new releases\n  as automated tests can no longer easily be run, i.e. once the Python\n  version is officially end-of-life.\n\n* **Testing**. The library has a test suite based on each rule of the\n  IDNA specification, as well as tests that are provided as part of the\n  Unicode Technical Standard 46, [Unicode IDNA Compatibility Processing](https://unicode.org/reports/tr46/).\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Transitional processing**. Unicode 16.0.0 removed transitional\n  processing so the `transitional` argument for the encode() method\n  no longer has any effect and will be removed at a later date.",
-      "release_date": "2026-05-12T22:45:55",
+      "description": "# Internationalized Domain Names in Applications (IDNA)\n\nSupport for [Internationalized Domain Names in Applications\n(IDNA)](https://tools.ietf.org/html/rfc5891) and [Unicode IDNA\nCompatibility Processing](https://unicode.org/reports/tr46/). It\nsupersedes the standard library's `encodings.idna`, which only\nimplements the 2003 specification, offering broader script coverage and\nlimiting domains with known security vulnerabilities.\n\n## Usage\n\nPackage may be installed from [PyPI](https://pypi.org/project/idna/) via\nthe typical methods (e.g. `python3 -m pip install idna`)\n\nFor typical usage, the `encode` and `decode` functions will take a\ndomain name argument and perform a conversion to ASCII-compatible encoding\n(known as A-labels), or to Unicode strings (known as U-labels)\nrespectively.\n\n```pycon\n>>> import idna\n>>> idna.encode('\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8')\nb'xn--eckwd4c7c.xn--zckzah'\n>>> print(idna.decode('xn--eckwd4c7c.xn--zckzah'))\n\u30c9\u30e1\u30a4\u30f3.\u30c6\u30b9\u30c8\n```\n\nConversions can be applied at a per-label basis using the `ulabel` or\n`alabel` functions for specialized use cases.\n\n\n### Compatibility Mapping (UTS #46)\n\nThis library provides support for [Unicode IDNA Compatibility\nProcessing](https://unicode.org/reports/tr46/) which normalizes input from\ndifferent potential ways a user may input a domain prior to performing the IDNA\nconversion operations. This functionality, known as a\n[mapping](https://tools.ietf.org/html/rfc5895), is considered by the\nspecification to be a local user-interface issue distinct from IDNA\nconversion functionality.\n\nFor example, \"K\u00f6nigsg\u00e4\u00dfchen\" is not a permissible label as capital letters\nare not allowed. UTS 46 will convert this into lower case prior to applying\nthe IDNA conversion.\n\n```pycon\n>>> import idna\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen')\n...\nidna.core.InvalidCodepoint: Codepoint U+004B at position 1 of 'K\u00f6nigsg\u00e4\u00dfchen' not allowed\n>>> idna.encode('K\u00f6nigsg\u00e4\u00dfchen', uts46=True)\nb'xn--knigsgchen-b4a3dun'\n>>> idna.decode('xn--knigsgchen-b4a3dun')\n'k\u00f6nigsg\u00e4\u00dfchen'\n```\n\n\n## Exceptions\n\nAll errors raised during conversion derive from the `idna.IDNAError`\nbase class. The more specific exceptions are:\n\n* `idna.IDNABidiError` \u2014 raised when a label contains an illegal\n  combination of left-to-right and right-to-left characters.\n* `idna.InvalidCodepoint` \u2014 raised when a label contains a codepoint\n  that is INVALID for IDNA.\n* `idna.InvalidCodepointContext` \u2014 raised when a CONTEXTO or CONTEXTJ\n  codepoint appears in a position whose contextual requirements are\n  not satisfied.\n\n\n## Command-line tool\n\nThe package supports command-line usage to convert domain names\nbetween their Unicode and ASCII-compatible forms. It can be run either\nas a module (`python3 -m idna`) or, once installed (such as with `uv\ntool` or `pipx`), via the `idna` script:\n\n```bash\n$ uv tool install idna\n$ idna xn--e1afmkfd.xn--p1ai\n\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\n$ idna \u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444\nxn--e1afmkfd.xn--p1ai\n```\n\nWith no mode flag the direction is chosen automatically: inputs\ncontaining an `xn--` label are decoded, anything else is encoded. Pass\n`-e`/`--encode` or `-d`/`--decode` to force a specific direction.\n\nMultiple domains may be supplied at once, either as positional arguments\nor by piping one domain per line on standard input. When more than\none domain is supplied without explicitly asking to encode or decode,\nthe direction is picked from the first input and that mode is applied\nto every remaining input. Use `-e`/`--encode` or `-d`/`--decode` to\noverride the heuristic if the first input is ambiguous.\n\nUTS #46 mapping is applied by default, which lets the tool accept\ninputs that aren't strictly valid IDNA 2008 by normalising them first:\n\n```bash\n$ idna \u03a0\u0391\u03a1\u0386\u0394\u0395\u0399\u0393\u039c\u0391.\u0395\u039b\nxn--hxajbheg2az3al.xn--qxam\n```\n\nPass `--strict` to disable UTS #46 and apply IDNA 2008 rules verbatim;\nthe same input will then be rejected.\n\nConversion failures are reported on stderr together with the\noffending input; processing continues with the remaining domains and\nthe tool exits with a non-zero status if any conversion failed.\n\n\n## Additional Notes\n\n* **Version support**. This library supports Python 3.9 and higher.\n  As this library serves as a low-level toolkit for a variety of\n  applications, we strive to support all versions of Python that are\n  not beyond end-of-life.\n\n* **Emoji**. It is an occasional request to support emoji domains in\n  this library. Encoding of symbols like emoji is expressly prohibited by\n  the IDNA technical standard, and emoji domains are broadly phased\n  out across the domain industry due to associated security risks.\n\n* **Regenerating lookup tables**. The IDNA and UTS 46 functionality\n  relies upon pre-calculated lookup tables, generated using the\n  `idna-data` script in [`tools/`](tools/README.md).",
+      "release_date": "2026-05-22T00:16:16",
       "parties": [
         {
           "type": "person",
@@ -664,7 +728,6 @@
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
@@ -673,28 +736,36 @@
         "Topic :: Utilities"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-      "size": 72340,
+      "download_url": "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl",
+      "size": 74165,
       "sha1": null,
-      "md5": "a1e6be4b7c837089c035bd5aec4feeca",
-      "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+      "md5": "6866dc1362986ffa0c4eee4c16a059cd",
+      "sha256": "cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/kjd/idna",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/kjd/idna.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz",
+          "sha256": "d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d",
+          "md5": "7dfcadedaaa152963f6e6ab0fcbe5aab",
+          "size": 203770,
+          "filename": "idna-3.16.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/idna/3.15/json",
+      "api_data_url": "https://pypi.org/pypi/idna/3.16/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/idna@3.15"
+      "purl": "pkg:pypi/idna@3.16"
     },
     {
       "type": "pypi",
@@ -754,7 +825,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz",
+          "sha256": "4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6",
+          "md5": "5ce182fd7f6152cda19ec605b6740687",
+          "size": 29705,
+          "filename": "isodate-0.7.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -814,7 +893,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip",
+          "sha256": "6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9",
+          "md5": "3079617446a011d4fc0098687609671e",
+          "size": 175332,
+          "filename": "msrest-0.7.1.zip"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -887,7 +974,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz",
+          "sha256": "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+          "md5": "856bc51662afb26ac58b1d7742606b2e",
+          "size": 185918,
+          "filename": "oauthlib-3.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -946,7 +1041,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz",
+          "sha256": "600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+          "md5": "56f3a0a82595b0cb04976cc0d3271a27",
+          "size": 103492,
+          "filename": "pycparser-3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1012,7 +1115,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz",
+          "sha256": "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9",
+          "md5": "713dc7856f9ff625d75335c10d332a1b",
+          "size": 55650,
+          "filename": "requests-oauthlib-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1076,7 +1187,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1088,7 +1199,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz",
+          "sha256": "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed",
+          "md5": "611e438d0803e962500225f9807a475e",
+          "size": 142856,
+          "filename": "requests-2.34.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1158,7 +1277,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz",
+          "sha256": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "md5": "079e529d0b271647f3ec2720aee8fc65",
+          "size": 109391,
+          "filename": "typing_extensions-4.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1227,14 +1354,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz",
+          "sha256": "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+          "md5": "e79707b798a66c8165c9c441440f4e80",
+          "size": 433602,
+          "filename": "urllib3-2.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1267,7 +1402,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -1281,7 +1416,7 @@
       "dependencies": []
     },
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
@@ -1291,7 +1426,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/idna@3.15",
+      "package": "pkg:pypi/idna@3.16",
       "dependencies": []
     },
     {
@@ -1302,7 +1437,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.41.0",
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.34.2"
@@ -1326,9 +1461,9 @@
     {
       "package": "pkg:pypi/requests@2.34.2",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/charset-normalizer@3.4.7",
-        "pkg:pypi/idna@3.15",
+        "pkg:pypi/idna@3.16",
         "pkg:pypi/urllib3@2.7.0"
       ]
     },

--- a/tests/data/azure-devops.req-38-expected.json
+++ b/tests/data/azure-devops.req-38-expected.json
@@ -176,7 +176,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/75/aa/7c9db8edd626f1a7d99d09ef7926f6f4fb34d5f9fa00dc394afdfe8e2a80/azure_core-1.33.0.tar.gz",
+          "sha256": "f367aa07b5e3005fec2c1e184b882b0b039910733907d001c20fb08ebb8c0eb9",
+          "md5": "4d727311bd4e0f2d64eb1254502acb99",
+          "size": 295633,
+          "filename": "azure_core-1.33.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -244,7 +252,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/f9/495982345252dc7a15ac632e038be1f975ca0d2f25abfe8f8d908569141d/azure-devops-7.1.0b4.tar.gz",
+          "sha256": "f04ba939112579f3d530cfecc044a74ef9e9339ba23c9ee1ece248241f07ff85",
+          "md5": "bf401acf6533d4a2dcfd2106ffcbc86a",
+          "size": 1336261,
+          "filename": "azure-devops-7.1.0b4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -305,7 +321,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/96/95/3e3414491ce45025a1cde107b6ae72bf72049e6021597c201cd6a3029b9a/azure_storage_blob-12.26.0.tar.gz",
+          "sha256": "5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f",
+          "md5": "78fd3866b0a62f8799e62fdcce0d2fe4",
+          "size": 583332,
+          "filename": "azure_storage_blob-12.26.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -317,12 +341,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -349,15 +373,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -369,13 +393,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -417,7 +449,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-cffi/cffi/issues",
       "code_view_url": "https://github.com/python-cffi/cffi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-cffi/cffi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -429,7 +461,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz",
+          "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+          "md5": "4336ca58b2df0cc3b163884d5fa2e5e2",
+          "size": 516621,
+          "filename": "cffi-1.17.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -502,7 +542,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/jawah/charset_normalizer",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/jawah/charset_normalizer.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -511,7 +551,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz",
+          "sha256": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+          "md5": "68805886064d248d2e5205fd11112d85",
+          "size": 144271,
+          "filename": "charset_normalizer-3.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -554,7 +602,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -565,7 +613,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz",
+          "sha256": "ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a",
+          "md5": "b52ee8e6c33d88a2b4626e6a6002245d",
+          "size": 226593,
+          "filename": "click-8.1.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -633,7 +689,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz",
+          "sha256": "4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971",
+          "md5": "c7c51e216abd722be0e8120e220c2473",
+          "size": 744980,
+          "filename": "cryptography-45.0.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -690,14 +754,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/kjd/idna",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/kjd/idna.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz",
+          "sha256": "ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc",
+          "md5": "d524f820dc616bbfd4130920ce826b94",
+          "size": 199245,
+          "filename": "idna-3.15.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -763,7 +835,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz",
+          "sha256": "4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6",
+          "md5": "5ce182fd7f6152cda19ec605b6740687",
+          "size": 29705,
+          "filename": "isodate-0.7.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -823,7 +903,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip",
+          "sha256": "6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9",
+          "md5": "3079617446a011d4fc0098687609671e",
+          "size": 175332,
+          "filename": "msrest-0.7.1.zip"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -896,7 +984,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz",
+          "sha256": "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+          "md5": "856bc51662afb26ac58b1d7742606b2e",
+          "size": 185918,
+          "filename": "oauthlib-3.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -961,7 +1057,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz",
+          "sha256": "78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2",
+          "md5": "bb4946a7b0d83569f5d29f566a55180a",
+          "size": 173734,
+          "filename": "pycparser-2.23.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1027,7 +1131,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz",
+          "sha256": "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9",
+          "md5": "713dc7856f9ff625d75335c10d332a1b",
+          "size": 55650,
+          "filename": "requests-oauthlib-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1083,7 +1195,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1095,7 +1207,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz",
+          "sha256": "27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422",
+          "md5": "4a380c14fe0f4465c9dbf79ffacefd8f",
+          "size": 135258,
+          "filename": "requests-2.32.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1151,7 +1271,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz",
+          "sha256": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+          "md5": "a0387fe15662c71057b4fb2b7aa9056a",
+          "size": 34031,
+          "filename": "six-1.17.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1221,7 +1349,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz",
+          "sha256": "e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef",
+          "md5": "58226788d248cee8d6283ee616543975",
+          "size": 106967,
+          "filename": "typing_extensions-4.13.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1290,7 +1426,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1301,7 +1437,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz",
+          "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+          "md5": "d65de4f0effae2b52669246f0aab0a91",
+          "size": 300677,
+          "filename": "urllib3-2.2.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1335,7 +1479,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -1370,7 +1514,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.33.0",
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.32.4"
@@ -1394,7 +1538,7 @@
     {
       "package": "pkg:pypi/requests@2.32.4",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/charset-normalizer@3.4.7",
         "pkg:pypi/idna@3.15",
         "pkg:pypi/urllib3@2.2.3"

--- a/tests/data/environment-marker-test-requirements.txt-expected.json
+++ b/tests/data/environment-marker-test-requirements.txt-expected.json
@@ -249,7 +249,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz",
+          "sha256": "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b",
+          "md5": "fc4cc00c4863833230d3af92af48abd4",
+          "size": 279019,
+          "filename": "click-6.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -310,7 +318,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/flask",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -322,7 +330,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz",
+          "sha256": "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c",
+          "md5": "7140df3116386c7af0f389800a91817b",
+          "size": 643442,
+          "filename": "Flask-1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -373,7 +389,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz",
+          "sha256": "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519",
+          "md5": "a3d55aa79369aef5345c036a8a26307f",
+          "size": 46541,
+          "filename": "itsdangerous-0.24.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -435,7 +459,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -447,7 +471,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz",
+          "sha256": "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6",
+          "md5": "231dc00d34afb2672c497713fa9cdaaa",
+          "size": 257589,
+          "filename": "Jinja2-2.11.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -506,7 +538,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz",
+          "sha256": "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
+          "md5": "2fcedc9284d50e577b5192e8e3578355",
+          "size": 14356,
+          "filename": "MarkupSafe-1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -571,7 +611,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -583,7 +623,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz",
+          "sha256": "cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3",
+          "md5": "2da857b57e7e4c5b6403369a9d1c15a9",
+          "size": 925615,
+          "filename": "Werkzeug-0.15.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/example-requirements-ignore-errors-expected.json
+++ b/tests/data/example-requirements-ignore-errors-expected.json
@@ -148,7 +148,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz",
+          "sha256": "8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219",
+          "md5": "f88685ec75c5715111d65aeae28c9322",
+          "size": 30371,
+          "filename": "exceptiongroup-1.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -206,7 +214,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz",
+          "sha256": "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+          "md5": "5c1d9c21275feb3da71400bf716edd72",
+          "size": 20503,
+          "filename": "iniconfig-2.3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -260,14 +276,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pypa/packaging",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pypa/packaging.git",
       "copyright": null,
       "license_expression": "Apache-2.0 OR BSD-2-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz",
+          "sha256": "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661",
+          "md5": "edae3d061c39a2ff713a97e133dbc50c",
+          "size": 228134,
+          "filename": "packaging-26.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -334,7 +358,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz",
+          "sha256": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+          "md5": "54391218af778acb006c2d915085d469",
+          "size": 69412,
+          "filename": "pluggy-1.6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -397,14 +429,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pygments/pygments/issues",
       "code_view_url": "https://github.com/pygments/pygments",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pygments/pygments.git",
       "copyright": null,
       "license_expression": "BSD-2-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz",
+          "sha256": "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+          "md5": "358297d0a1db8e4beff8eebc0620960e",
+          "size": 4955991,
+          "filename": "pygments-2.20.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -459,14 +499,22 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pytest-dev/pytest/issues",
       "code_view_url": "https://github.com/pytest-dev/pytest",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pytest-dev/pytest.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz",
+          "sha256": "b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c",
+          "md5": "0cd1c357553d2e3eb850d71843b375d1",
+          "size": 1572165,
+          "filename": "pytest-9.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -520,7 +568,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz",
+          "sha256": "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f",
+          "md5": "74df8e3714ffa480b8076c98247ae1d1",
+          "size": 17543,
+          "filename": "tomli-2.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -590,7 +646,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz",
+          "sha256": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "md5": "079e529d0b271647f3ec2720aee8fc65",
+          "size": 109391,
+          "filename": "typing_extensions-4.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/frozen-requirements.txt-expected.json
+++ b/tests/data/frozen-requirements.txt-expected.json
@@ -1551,7 +1551,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/22/11/fb1a48393106b470fc05450a01317f22ca128541d5c5f755ce092ffaebd0/aboutcode-toolkit-7.0.2.tar.gz",
+          "sha256": "b0bc22ff777187adf5ac50ceb81b3e44dcbf9d7239ecf8b1a80a1ac1ac87a2b5",
+          "md5": "b29726a260d0da5c09caf5f07646d766",
+          "size": 380081,
+          "filename": "aboutcode-toolkit-7.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1616,7 +1624,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-attrs/attrs/issues",
       "code_view_url": "https://github.com/python-attrs/attrs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-attrs/attrs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1628,7 +1636,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d7/77/ebb15fc26d0f815839ecd897b919ed6d85c050feeb83e100e020df9153d2/attrs-21.4.0.tar.gz",
+          "sha256": "626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd",
+          "md5": "5a9b5e9ceebc380a13fb93235b11bbda",
+          "size": 201839,
+          "filename": "attrs-21.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1686,7 +1702,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e8/b0/cd2b968000577ec5ce6c741a54d846dfa402372369b8b6861720aa9ecea7/beautifulsoup4-4.11.1.tar.gz",
+          "sha256": "ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693",
+          "md5": "22f22f89cf9da41b22e1ece9639c66a3",
+          "size": 517113,
+          "filename": "beautifulsoup4-4.11.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1750,7 +1774,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ee/1f/b29c7371958ab41a800f8718f5d285bf4333b8d0b5a5a8650234463ee644/black-22.3.0.tar.gz",
+          "sha256": "35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
+          "md5": "1ae8332ebbdc492dcb53c9e8df2ec4f9",
+          "size": 554277,
+          "filename": "black-22.3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1813,7 +1845,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6a/a3/217842324374fd3fb33db0eb4c2909ccf3ecc5a94f458088ac68581f8314/bleach-4.1.0.tar.gz",
+          "sha256": "0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da",
+          "md5": "41e70ac58aa7bc5ff96c8fef24b9d659",
+          "size": 195798,
+          "filename": "bleach-4.1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1873,7 +1913,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a2/d9/b6e56a303d221fc0bdff2c775e4eef7fedd58194aa5a96fa89fb71634cc9/boolean.py-4.0.tar.gz",
+          "sha256": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4",
+          "md5": "5a8b0eae254b0c37a1bdde38c6bd5b5d",
+          "size": 34504,
+          "filename": "boolean.py-4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1921,7 +1969,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1933,7 +1981,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz",
+          "sha256": "9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
+          "md5": "70f3688480b8fc4556c033f3ea655d36",
+          "size": 156701,
+          "filename": "certifi-2022.5.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1994,7 +2050,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz",
+          "sha256": "920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954",
+          "md5": "f3a3f26cd3335fc597479c9475da0a0b",
+          "size": 484058,
+          "filename": "cffi-1.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2069,7 +2133,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz",
+          "sha256": "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+          "md5": "f6664e0e90dbb3cc9cfc154a980f9864",
+          "size": 79105,
+          "filename": "charset-normalizer-2.0.12.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2118,7 +2190,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/click/issues/",
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2130,7 +2202,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/cf/706c1ad49ab26abed0b77a2f867984c1341ed7387b8030a6aa914e2942a0/click-8.0.4.tar.gz",
+          "sha256": "8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb",
+          "md5": "c89efc98d1b36d52ba26a39c803df0cc",
+          "size": 329520,
+          "filename": "click-8.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2203,7 +2283,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz",
+          "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+          "md5": "57b22f2597f63df051b69906fbf310cc",
+          "size": 27813,
+          "filename": "colorama-0.4.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2258,7 +2346,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/8b/65/99ad49681e8897ab851014f18bf51e8081a492efc1ef0b443209f7a83e0e/commoncode-30.2.0.tar.gz",
+          "sha256": "ee470359fc3833b6e87b40013b8a1bd5df973b56314bddb89ad1844ef1e835fd",
+          "md5": "754bc02c505adcf65a8d1006b7894703",
+          "size": 1690459,
+          "filename": "commoncode-30.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2315,7 +2411,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pyca/cryptography/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pyca/cryptography.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2328,7 +2424,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/51/05/bb2b681f6a77276fc423d04187c39dafdb65b799c8d87b62ca82659f9ead/cryptography-37.0.2.tar.gz",
+          "sha256": "f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e",
+          "md5": "7477bd10af69e78aed4c83accd401416",
+          "size": 585433,
+          "filename": "cryptography-37.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2433,7 +2537,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/57/b1/b880503681ea1b64df05106fc7e3c4e3801736cf63deffc6fa7fc5404cf5/docutils-0.18.1.tar.gz",
+          "sha256": "679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06",
+          "md5": "ca5827e2432fd58f4c8d74a6591135de",
+          "size": 2043249,
+          "filename": "docutils-0.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2493,7 +2605,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2d/a3/49cd39abdf8b4832cba27d635a775b721388e50671bee7ea0d10afcf0cfd/dparse2-0.6.1.tar.gz",
+          "sha256": "fbafb839c3dc83040012af2602a00ca4e4b1693a9b1988492150466afa59dd26",
+          "md5": "8d8c7be322b2211c5c5eea6150da2832",
+          "size": 10458,
+          "filename": "dparse2-0.6.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2552,7 +2672,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3d/5d/0413a31d184a20c763ad741cc7852a659bf15094c24840c5bdd1754765cd/et_xmlfile-1.1.0.tar.gz",
+          "sha256": "8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c",
+          "md5": "8fbae9b969eac28c02f5073febefc445",
+          "size": 3218,
+          "filename": "et_xmlfile-1.1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2620,7 +2748,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7a/3c/b5ac9fc61e1e559ced3e40bf5b518a4142536b34eb274aa50dff29cb89f5/execnet-1.9.0.tar.gz",
+          "sha256": "8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5",
+          "md5": "69f7f721586d5a02b66cac7cb388b7e3",
+          "size": 173884,
+          "filename": "execnet-1.9.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2675,7 +2811,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2687,7 +2823,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2755,7 +2899,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz",
+          "sha256": "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
+          "md5": "5856306eac5f25db8249e37a4c6ee3e7",
+          "size": 286689,
+          "filename": "idna-3.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2808,7 +2960,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/85/ed/e65128cc5cb1580f22ee3009d9187ecdfcc43ffb3b581fe854b24e87d8e7/importlib_metadata-4.8.3.tar.gz",
+          "sha256": "766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668",
+          "md5": "833c41fd427678c8b590c5a7818dd873",
+          "size": 41979,
+          "filename": "importlib_metadata-4.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2868,7 +3028,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz",
+          "sha256": "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32",
+          "md5": "0b7f3be87481211c183eae095bcea6f1",
+          "size": 8104,
+          "filename": "iniconfig-1.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2926,7 +3094,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f8/80/81bf8129a2cc012a225ea0dc39cd6e11531a61d115616b1eead33b157164/intbitset-3.0.1.tar.gz",
+          "sha256": "f1e6d03c6729922a223c51849df65b9e916e625aefb911784e7f9acd4c207d53",
+          "md5": "8f417e4ec5879841fde7aa873320ffdc",
+          "size": 151831,
+          "filename": "intbitset-3.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2997,7 +3173,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz",
+          "sha256": "e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
+          "md5": "717294d0a9017b27bd46b1c946b39bd0",
+          "size": 174062,
+          "filename": "isort-5.10.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3046,7 +3230,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/itsdangerous/issues/",
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3058,7 +3242,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz",
+          "sha256": "5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a",
+          "md5": "c1bc730ddf53b8374eaa823f24eb6438",
+          "size": 56143,
+          "filename": "itsdangerous-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3109,7 +3301,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/09/0d/81744e179cf3aede2d117c20c6d5b97a62ffe16b2ca5d856e068e81c7a68/jeepney-0.7.1.tar.gz",
+          "sha256": "fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f",
+          "md5": "d804ad938b27d9b761f2c44f8d33fef6",
+          "size": 61833,
+          "filename": "jeepney-0.7.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3161,7 +3361,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/jinja/issues/",
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3173,7 +3373,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz",
+          "sha256": "611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7",
+          "md5": "b76ae2f0647abebc81e7c03f5fb7b00f",
+          "size": 269196,
+          "filename": "Jinja2-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3234,7 +3442,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6f/23/143b4adec7d6957d35c0fc90c095203046da04eb5eade7fef8b00fe421fc/keyring-23.4.1.tar.gz",
+          "sha256": "89cbd74d4683ed164c8082fb38619341097741323b3786905c6dac04d6915a55",
+          "md5": "e1d85ffb9b2ba1032068c361e2431b3c",
+          "size": 54135,
+          "filename": "keyring-23.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3296,7 +3512,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/80/ad/9b3614c4630f3a1c0d5d7e5f6cfa8e90850186864e1181e86a65150d983f/license-expression-30.0.0.tar.gz",
+          "sha256": "ad638292aa8493f84354909b517922cb823582c2ce2c4d880e42544a86bea8dd",
+          "md5": "253c39f105199625d9ac35f0a50976e2",
+          "size": 158232,
+          "filename": "license-expression-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3348,7 +3572,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/markupsafe/issues/",
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3360,7 +3584,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
+          "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+          "md5": "892e0fefa3c488387e5cc0cad2daa523",
+          "size": 18596,
+          "filename": "MarkupSafe-2.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3422,7 +3654,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz",
+          "sha256": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
+          "md5": "4163ff73d0db8631c0a78bb55b551c84",
+          "size": 4252,
+          "filename": "mypy_extensions-0.4.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3469,7 +3709,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/openpyxl/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/openpyxl",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/openpyxl.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3481,7 +3721,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2c/b8/ff77a718173fd73e49f883b4fda88f11af1fc51edb9252af3785b0cad987/openpyxl-3.0.10.tar.gz",
+          "sha256": "e47805627aebcf860edb4edf7987b1309c1b3632f3750538ed962bbcc3bd7449",
+          "md5": "ebcc3a30768a45163d5143f1f7bf0224",
+          "size": 179688,
+          "filename": "openpyxl-3.0.10.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3546,7 +3794,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6e/ee/8d89d660da6e44d77f547de9949b380dc93b08b758ee361bc237bcc8b179/packageurl-python-0.9.9.tar.gz",
+          "sha256": "872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09",
+          "md5": "35651efef038a54f5083197038d358c0",
+          "size": 30107,
+          "filename": "packageurl-python-0.9.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3609,7 +3865,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz",
+          "sha256": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+          "md5": "e713c1939f294fd729af4a7be40dd141",
+          "size": 84848,
+          "filename": "packaging-21.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3675,7 +3939,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f6/33/436c5cb94e9f8902e59d1d544eb298b83c84b9ec37b5b769c5a0ad6edb19/pathspec-0.9.0.tar.gz",
+          "sha256": "e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
+          "md5": "9b6b70fa5ffc31e6f5700522880140c0",
+          "size": 29483,
+          "filename": "pathspec-0.9.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3729,7 +4001,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fc/aa/4fbc8040db7afae616eda6329ddc8ef73afc8bcb611bf9126937970bca83/pip-requirements-parser-31.2.0.tar.gz",
+          "sha256": "8c2a6f8e091ac2693824a5ef4e3b250226e34f74a20a91a87b9ab0714b47788f",
+          "md5": "a202d8dda5f2840181b80d4c81fa63d0",
+          "size": 209659,
+          "filename": "pip-requirements-parser-31.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3781,7 +4061,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pypa/pip",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pypa/pip.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3793,7 +4073,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/70/53/b309b4a497b09655cb7e07088966881a57d082f48ac3cb54ea729fd2c6cf/pip-25.0.1.tar.gz",
+          "sha256": "88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea",
+          "md5": "1bf81564bf9738efbe48439c230f25bf",
+          "size": 1950850,
+          "filename": "pip-25.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3853,7 +4141,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9e/c0/2ca9cb24d8045a1c84bdeca2b2646fcf438266a930301a7672c4cb8d0ff9/pipdeptree-2.2.1.tar.gz",
+          "sha256": "2b97d80c64d229e01ad242f14229a899263c6e8645c588ec5b054c1b81f3065d",
+          "md5": "05cab13fbae0ebb7015a6ce6757000e7",
+          "size": 22430,
+          "filename": "pipdeptree-2.2.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3915,7 +4211,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/90/8d/09cc1c99a30ac14050fc4e04e549e024be83ff72a7f63e75023501baf977/pkginfo2-30.0.0.tar.gz",
+          "sha256": "5e1afbeb156febb407a9b5c16b51c5b4737c529eeda2b1607e1e277cf260669c",
+          "md5": "8fd5bd0d69938534c9796195164b5928",
+          "size": 364071,
+          "filename": "pkginfo2-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3978,7 +4282,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/00/91/fe0806e3ebded8c4e52f93ab4d963eef34bb33595c7aa7b5591d32ab5b92/pkginfo-1.8.3.tar.gz",
+          "sha256": "a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c",
+          "md5": "e67d8f6e37ca37b5512384655bbce760",
+          "size": 375734,
+          "filename": "pkginfo-1.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4031,7 +4343,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/platformdirs/platformdirs/issues",
       "code_view_url": "https://github.com/platformdirs/platformdirs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/platformdirs/platformdirs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4043,7 +4355,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4b/96/d70b9462671fbeaacba4639ff866fb4e9e558580853fc5d6e698d0371ad4/platformdirs-2.4.0.tar.gz",
+          "sha256": "367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+          "md5": "4e5b836d19600cc4bf0b789ab1de3b51",
+          "size": 24051,
+          "filename": "platformdirs-2.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4109,7 +4429,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz",
+          "sha256": "4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+          "md5": "daa6fddfb6cd364f3c82e52098911e4b",
+          "size": 51510,
+          "filename": "pluggy-1.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4179,7 +4507,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz",
+          "sha256": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+          "md5": "bde7dcc1cb452a1e10206ef2f811ba88",
+          "size": 207796,
+          "filename": "py-1.11.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4256,7 +4592,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/08/dc/b29daf0a202b03f57c19e7295b60d1d5e1281c45a6f5f573e41830819918/pycodestyle-2.8.0.tar.gz",
+          "sha256": "eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f",
+          "md5": "7f4f7cc6634e9388a8bbd35f92e66a6b",
+          "size": 102299,
+          "filename": "pycodestyle-2.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4317,7 +4661,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz",
+          "sha256": "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206",
+          "md5": "48f7d743bf018f7bb2ffc5fb976d1492",
+          "size": 170877,
+          "filename": "pycparser-2.21.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4372,7 +4724,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pygments/pygments/issues",
       "code_view_url": "https://github.com/pygments/pygments",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pygments/pygments.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4384,7 +4736,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz",
+          "sha256": "5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+          "md5": "2137c19d9ac0cc556badc89e746c0e62",
+          "size": 4282017,
+          "filename": "Pygments-2.12.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4448,7 +4808,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz",
+          "sha256": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+          "md5": "fadc2f3bf5872bf6310576a86c3566e0",
+          "size": 1999906,
+          "filename": "pyparsing-3.0.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4514,7 +4882,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f1/bc/0121a2e386b261b69f4f5aa48e5304c947451dce70d68628cb28d5cd0d28/pytest-forked-1.4.0.tar.gz",
+          "sha256": "8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e",
+          "md5": "fc2d4bb78f3a5e7c082173527d5009d3",
+          "size": 10197,
+          "filename": "pytest-forked-1.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4581,7 +4957,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/5d/43/9dbc32d297d6eae85d6c05dc8e8d3371061bd6cbe56a2f645d9ea4b53d9b/pytest-xdist-2.5.0.tar.gz",
+          "sha256": "4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf",
+          "md5": "aaec318fa6e83d99bd366d3ef45252da",
+          "size": 72455,
+          "filename": "pytest-xdist-2.5.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4636,7 +5020,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pytest-dev/pytest/issues",
       "code_view_url": "https://github.com/pytest-dev/pytest",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pytest-dev/pytest.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4648,7 +5032,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3e/2c/a67ad48759051c7abf82ce182a4e6d766de371b183182d2dde03089e8dfb/pytest-7.0.1.tar.gz",
+          "sha256": "e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171",
+          "md5": "995d64fe44bbe717d03bd703d5c48ec6",
+          "size": 1249154,
+          "filename": "pytest-7.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4701,7 +5093,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/yaml/pyyaml/issues",
       "code_view_url": "https://github.com/yaml/pyyaml",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/yaml/pyyaml.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4713,7 +5105,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+          "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+          "md5": "1d19c798f25e58e3e582f0f8c977dbb8",
+          "size": 124996,
+          "filename": "PyYAML-6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4780,7 +5180,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/52/c5/6c090aad067a6f05681367fc33ab2c8d571a3739405bec60f7ba486e83de/readme_renderer-34.0.tar.gz",
+          "sha256": "dfb4d17f21706d145f7473e0b61ca245ba58e810cf9b2209a48239677f82e5b0",
+          "md5": "a7e83bdafe0e71b6d4786566de7430fd",
+          "size": 28835,
+          "filename": "readme_renderer-34.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4840,7 +5248,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/28/30/7bf7e5071081f761766d46820e52f4b16c8a08fef02d2eb4682ca7534310/requests-toolbelt-0.9.1.tar.gz",
+          "sha256": "968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0",
+          "md5": "b1509735c4b4cf95df2619facbc3672e",
+          "size": 207286,
+          "filename": "requests-toolbelt-0.9.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4896,7 +5312,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4908,7 +5324,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz",
+          "sha256": "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+          "md5": "bcc01b73974a305cc7c5b092e7d07004",
+          "size": 106758,
+          "filename": "requests-2.27.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4966,7 +5390,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/20/9541749d77aebf66dd92e2b803f38a50e3a5c76e7876f45eb2b37e758d82/resolvelib-0.8.1.tar.gz",
+          "sha256": "c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+          "md5": "fbd5fbcac181644333390ea6a71c4edc",
+          "size": 17308,
+          "filename": "resolvelib-0.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5026,7 +5458,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz",
+          "sha256": "270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
+          "md5": "0e3a03c3eb3b679d5a253b168bb5774a",
+          "size": 49378,
+          "filename": "rfc3986-1.5.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5080,7 +5520,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/4a/7374cac103bdfec7c199606784119bee9171ba051290b219ffec1bedc650/saneyaml-0.5.2.tar.gz",
+          "sha256": "d6074f1959041342ab41d74a6f904720ffbcf63c94467858e0e22e17e3c43d41",
+          "md5": "4985d7a8f4ad5af6ae53132e8d23a247",
+          "size": 32034,
+          "filename": "saneyaml-0.5.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5141,7 +5589,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bc/3b/6e294fcaa5aed4059f2aa01a1ee7d343953521f8e0f6965ebcf63c950269/SecretStorage-3.3.2.tar.gz",
+          "sha256": "0a8eb9645b320881c222e827c26f4cfcf55363e8b374a021981ef886657a912f",
+          "md5": "4de3603efceaeba6194a833c32365812",
+          "size": 19285,
+          "filename": "SecretStorage-3.3.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5197,7 +5653,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz",
+          "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+          "md5": "a7c927740e4964dd29b72cebfc1429bb",
+          "size": 34041,
+          "filename": "six-1.16.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5265,7 +5729,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/03/bac179d539362319b4779a00764e95f7542f4920084163db6b0fd4742d38/soupsieve-2.3.2.post1.tar.gz",
+          "sha256": "fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d",
+          "md5": "4c824620563604cbf783de149c8b8889",
+          "size": 102814,
+          "filename": "soupsieve-2.3.2.post1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5331,7 +5803,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz",
+          "sha256": "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93",
+          "md5": "53a0a6c5aef8f5eb5834e78e0fdf0499",
+          "size": 76885,
+          "filename": "text-unidecode-1.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5398,7 +5878,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+          "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+          "md5": "59bce5d8d67e858735ec3f399ec90253",
+          "size": 22253,
+          "filename": "toml-0.10.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5461,7 +5949,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fb/2e/d0a8276b0cf9b9e34fd0660c330acc59656f53bb2209adc75af863a3582d/tomli-1.2.3.tar.gz",
+          "sha256": "05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
+          "md5": "807cc80e6a2697375f431b757994b7c5",
+          "size": 15094,
+          "filename": "tomli-1.2.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5563,7 +6059,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/tqdm/tqdm",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/tqdm/tqdm.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5576,7 +6072,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/98/2a/838de32e09bd511cf69fe4ae13ffc748ac143449bfc24bb3fd172d53a84f/tqdm-4.64.0.tar.gz",
+          "sha256": "40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
+          "md5": "231212e145ac51214286b310704447d4",
+          "size": 169499,
+          "filename": "tqdm-4.64.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5630,7 +6134,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pypa/twine/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pypa/twine.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5641,7 +6145,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/3e/ce331d7e215abdc16c53e65f8506bfccf4840ce191b709a37b8c83cc32c7/twine-3.8.0.tar.gz",
+          "sha256": "8efa52658e0ae770686a13b675569328f1fba9837e5de1867bfe5f46a9aefe19",
+          "md5": "7f904fed5983ea072e1b229486ba4647",
+          "size": 214568,
+          "filename": "twine-3.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5714,7 +6226,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b1/5a/8b5fbb891ef3f81fc923bf3cb4a578c0abf9471eb50ce0f51c74212182ab/typing_extensions-4.1.1.tar.gz",
+          "sha256": "1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+          "md5": "3cd9b7b9a465afbcca8548e11668ca64",
+          "size": 26694,
+          "filename": "typing_extensions-4.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5771,7 +6291,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5783,7 +6303,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/a5/4eab74853625505725cefdf168f48661b2cd04e7843ab836f3f63abf81da/urllib3-1.26.9.tar.gz",
+          "sha256": "aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e",
+          "md5": "d4b58522821a33c5e421191b83e0dbac",
+          "size": 295258,
+          "filename": "urllib3-1.26.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5847,7 +6375,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz",
+          "sha256": "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923",
+          "md5": "32f6e261d52e57bf7e1c4d41546d15b8",
+          "size": 9721,
+          "filename": "webencodings-0.5.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5902,7 +6438,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/werkzeug/issues/",
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5914,7 +6450,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/10/cf/97eb1a3847c01ae53e8376bc21145555ac95279523a935963dc8ff96c50b/Werkzeug-2.1.2.tar.gz",
+          "sha256": "1ce08e8093ed67d638d63879fd1ba3735817f7a80de3674d293f5984f25fb6e6",
+          "md5": "5835c8738b8081c53367cbcc5db8784c",
+          "size": 835169,
+          "filename": "Werkzeug-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5967,7 +6511,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/02/bf/0d03dbdedb83afec081fefe86cae3a2447250ef1a81ac601a9a56e785401/zipp-3.6.0.tar.gz",
+          "sha256": "71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+          "md5": "8d5cf6eb3270384ae13a6440797ea564",
+          "size": 13047,
+          "filename": "zipp-3.6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/hash-requirements.txt-expected.json
+++ b/tests/data/hash-requirements.txt-expected.json
@@ -157,7 +157,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/85/ef/fd7649da8af11d93979831e8f1f8097e85e82d5bfeabc8c68b39175d8e75/addict-2.4.0.tar.gz",
+          "sha256": "b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494",
+          "md5": "b9354606535ea6a8a0a7a2d1798b3774",
+          "size": 9186,
+          "filename": "addict-2.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -169,12 +177,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2026.4.22",
+      "version": "2026.5.20",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2026-04-22T11:26:09",
+      "release_date": "2026-05-20T11:46:48",
       "parties": [
         {
           "type": "person",
@@ -201,15 +209,15 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-      "size": 135707,
+      "download_url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl",
+      "size": 134134,
       "sha1": null,
-      "md5": "a524df3261ff972bbe811eb7307a79ed",
-      "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+      "md5": "09ac8b5eddc520f3f2d5e6f7ee949553",
+      "sha256": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -221,13 +229,21 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz",
+          "sha256": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
+          "md5": "5bd96239568bc44f001858c99bf6352e",
+          "size": 135422,
+          "filename": "certifi-2026.5.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2026.4.22/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2026.5.20/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2026.4.22"
+      "purl": "pkg:pypi/certifi@2026.5.20"
     },
     {
       "type": "pypi",
@@ -297,7 +313,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
+          "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+          "md5": "bc9a5603d8d0994b2d4cbf255f99e654",
+          "size": 1907771,
+          "filename": "chardet-4.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -365,7 +389,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz",
+          "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+          "md5": "7a910c706db30d758f377db2762c0f9a",
+          "size": 175616,
+          "filename": "idna-2.10.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -417,7 +449,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -429,7 +461,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz",
+          "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+          "md5": "514d6f7eba77ada0b8c98ec7818828db",
+          "size": 102161,
+          "filename": "requests-2.25.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -487,7 +527,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -499,7 +539,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
+          "sha256": "40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32",
+          "md5": "a2720182586f0ccb1ac34df9f24b0aee",
+          "size": 307380,
+          "filename": "urllib3-1.26.20.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -514,7 +562,7 @@
       "dependencies": []
     },
     {
-      "package": "pkg:pypi/certifi@2026.4.22",
+      "package": "pkg:pypi/certifi@2026.5.20",
       "dependencies": []
     },
     {
@@ -528,7 +576,7 @@
     {
       "package": "pkg:pypi/requests@2.25.1",
       "dependencies": [
-        "pkg:pypi/certifi@2026.4.22",
+        "pkg:pypi/certifi@2026.5.20",
         "pkg:pypi/chardet@4.0.0",
         "pkg:pypi/idna@2.10",
         "pkg:pypi/urllib3@1.26.20"

--- a/tests/data/insecure-setup/setup.py-expected.json
+++ b/tests/data/insecure-setup/setup.py-expected.json
@@ -178,7 +178,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/40/32ce777053517be3032bb2ab3bb216959071ee0c16c761879e75c34a323e/isodate-0.7.0.tar.gz",
+          "sha256": "c6332cf456314b85cc3b6ea2c45a6fa417cb1fddb361f6d2ed8f4f69e843c6d1",
+          "md5": "06c2886cc00cdfc4ec1f36c1d590bc06",
+          "size": 29597,
+          "filename": "isodate-0.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -243,7 +251,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz",
+          "sha256": "c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+          "md5": "f0953e47a0112f7a65aec2305ffdf7b4",
+          "size": 649718,
+          "filename": "pyparsing-2.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -299,7 +315,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz",
+          "sha256": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+          "md5": "a0387fe15662c71057b4fb2b7aa9056a",
+          "size": 34031,
+          "filename": "six-1.17.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/no-install-requires-expected.json
+++ b/tests/data/no-install-requires-expected.json
@@ -73,7 +73,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1e/8b/3ea72ac8e26090b63779b4e0074af79b02bbbab7ddd01b36109bc0892d31/crontab-1.0.4.tar.gz",
+          "sha256": "715b0e5e105bc62c9683cbb93c1cc5821e07a3e28d17404576d22dba7a896c92",
+          "md5": "ad190b69ff4199c44a5170daf896e73f",
+          "size": 21677,
+          "filename": "crontab-1.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/pdt-requirements.txt-expected.json
+++ b/tests/data/pdt-requirements.txt-expected.json
@@ -228,7 +228,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz",
+          "sha256": "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b",
+          "md5": "fc4cc00c4863833230d3af92af48abd4",
+          "size": 279019,
+          "filename": "click-6.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -289,7 +297,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/flask",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -301,7 +309,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz",
+          "sha256": "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c",
+          "md5": "7140df3116386c7af0f389800a91817b",
+          "size": 643442,
+          "filename": "Flask-1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -352,7 +368,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz",
+          "sha256": "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519",
+          "md5": "a3d55aa79369aef5345c036a8a26307f",
+          "size": 46541,
+          "filename": "itsdangerous-0.24.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -414,7 +438,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -426,7 +450,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz",
+          "sha256": "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6",
+          "md5": "231dc00d34afb2672c497713fa9cdaaa",
+          "size": 257589,
+          "filename": "Jinja2-2.11.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -485,7 +517,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz",
+          "sha256": "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
+          "md5": "2fcedc9284d50e577b5192e8e3578355",
+          "size": 14356,
+          "filename": "MarkupSafe-1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -550,7 +590,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -562,7 +602,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz",
+          "sha256": "cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3",
+          "md5": "2da857b57e7e4c5b6403369a9d1c15a9",
+          "size": 925615,
+          "filename": "Werkzeug-0.15.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/pinned-pdt-requirements.txt-expected.json
+++ b/tests/data/pinned-pdt-requirements.txt-expected.json
@@ -753,7 +753,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/22/11/fb1a48393106b470fc05450a01317f22ca128541d5c5f755ce092ffaebd0/aboutcode-toolkit-7.0.2.tar.gz",
+          "sha256": "b0bc22ff777187adf5ac50ceb81b3e44dcbf9d7239ecf8b1a80a1ac1ac87a2b5",
+          "md5": "b29726a260d0da5c09caf5f07646d766",
+          "size": 380081,
+          "filename": "aboutcode-toolkit-7.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -818,7 +826,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-attrs/attrs/issues",
       "code_view_url": "https://github.com/python-attrs/attrs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-attrs/attrs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -830,7 +838,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d7/77/ebb15fc26d0f815839ecd897b919ed6d85c050feeb83e100e020df9153d2/attrs-21.4.0.tar.gz",
+          "sha256": "626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd",
+          "md5": "5a9b5e9ceebc380a13fb93235b11bbda",
+          "size": 201839,
+          "filename": "attrs-21.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -888,7 +904,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e8/b0/cd2b968000577ec5ce6c741a54d846dfa402372369b8b6861720aa9ecea7/beautifulsoup4-4.11.1.tar.gz",
+          "sha256": "ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693",
+          "md5": "22f22f89cf9da41b22e1ece9639c66a3",
+          "size": 517113,
+          "filename": "beautifulsoup4-4.11.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -948,7 +972,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a2/d9/b6e56a303d221fc0bdff2c775e4eef7fedd58194aa5a96fa89fb71634cc9/boolean.py-4.0.tar.gz",
+          "sha256": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4",
+          "md5": "5a8b0eae254b0c37a1bdde38c6bd5b5d",
+          "size": 34504,
+          "filename": "boolean.py-4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -996,7 +1028,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1008,7 +1040,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz",
+          "sha256": "9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
+          "md5": "70f3688480b8fc4556c033f3ea655d36",
+          "size": 156701,
+          "filename": "certifi-2022.5.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1083,7 +1123,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz",
+          "sha256": "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+          "md5": "f6664e0e90dbb3cc9cfc154a980f9864",
+          "size": 79105,
+          "filename": "charset-normalizer-2.0.12.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1132,7 +1180,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/click/issues/",
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1144,7 +1192,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/cf/706c1ad49ab26abed0b77a2f867984c1341ed7387b8030a6aa914e2942a0/click-8.0.4.tar.gz",
+          "sha256": "8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb",
+          "md5": "c89efc98d1b36d52ba26a39c803df0cc",
+          "size": 329520,
+          "filename": "click-8.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1217,7 +1273,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz",
+          "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+          "md5": "57b22f2597f63df051b69906fbf310cc",
+          "size": 27813,
+          "filename": "colorama-0.4.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1272,7 +1336,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/8b/65/99ad49681e8897ab851014f18bf51e8081a492efc1ef0b443209f7a83e0e/commoncode-30.2.0.tar.gz",
+          "sha256": "ee470359fc3833b6e87b40013b8a1bd5df973b56314bddb89ad1844ef1e835fd",
+          "md5": "754bc02c505adcf65a8d1006b7894703",
+          "size": 1690459,
+          "filename": "commoncode-30.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1332,7 +1404,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2d/a3/49cd39abdf8b4832cba27d635a775b721388e50671bee7ea0d10afcf0cfd/dparse2-0.6.1.tar.gz",
+          "sha256": "fbafb839c3dc83040012af2602a00ca4e4b1693a9b1988492150466afa59dd26",
+          "md5": "8d8c7be322b2211c5c5eea6150da2832",
+          "size": 10458,
+          "filename": "dparse2-0.6.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1381,7 +1461,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/et_xmfile/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/et_xmlfile",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/et_xmlfile.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1393,7 +1473,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz",
+          "sha256": "dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54",
+          "md5": "d7db773c110c5534e61f288fdfcad807",
+          "size": 17234,
+          "filename": "et_xmlfile-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1461,7 +1549,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz",
+          "sha256": "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
+          "md5": "5856306eac5f25db8249e37a4c6ee3e7",
+          "size": 286689,
+          "filename": "idna-3.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1514,7 +1610,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/85/ed/e65128cc5cb1580f22ee3009d9187ecdfcc43ffb3b581fe854b24e87d8e7/importlib_metadata-4.8.3.tar.gz",
+          "sha256": "766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668",
+          "md5": "833c41fd427678c8b590c5a7818dd873",
+          "size": 41979,
+          "filename": "importlib_metadata-4.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1572,7 +1676,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f8/80/81bf8129a2cc012a225ea0dc39cd6e11531a61d115616b1eead33b157164/intbitset-3.0.1.tar.gz",
+          "sha256": "f1e6d03c6729922a223c51849df65b9e916e625aefb911784e7f9acd4c207d53",
+          "md5": "8f417e4ec5879841fde7aa873320ffdc",
+          "size": 151831,
+          "filename": "intbitset-3.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1618,7 +1730,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1629,7 +1741,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1691,7 +1811,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/57/8b/dbe230196eee2de208ba87dcfae69c46db9d7ed70e2f30f143bf994ee075/license_expression-30.3.1.tar.gz",
+          "sha256": "60d5bec1f3364c256a92b9a08583d7ea933c7aa272c8d36d04144a89a3858c01",
+          "md5": "030df78064748876ca852e8b5ac0d407",
+          "size": 174601,
+          "filename": "license_expression-30.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1736,7 +1864,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/markupsafe/issues/",
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1748,7 +1876,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
+          "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+          "md5": "8fe7227653f2fb9b1ffe7f9f2058998a",
+          "size": 19384,
+          "filename": "MarkupSafe-2.1.5.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1797,7 +1933,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/openpyxl/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/openpyxl",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/openpyxl.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1809,7 +1945,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz",
+          "sha256": "cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050",
+          "md5": "13e63bdced2dbca00c8741eea3ecfa1c",
+          "size": 186464,
+          "filename": "openpyxl-3.1.5.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1874,7 +2018,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6e/ee/8d89d660da6e44d77f547de9949b380dc93b08b758ee361bc237bcc8b179/packageurl-python-0.9.9.tar.gz",
+          "sha256": "872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09",
+          "md5": "35651efef038a54f5083197038d358c0",
+          "size": 30107,
+          "filename": "packageurl-python-0.9.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1937,7 +2089,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz",
+          "sha256": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+          "md5": "e713c1939f294fd729af4a7be40dd141",
+          "size": 84848,
+          "filename": "packaging-21.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1991,7 +2151,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fc/aa/4fbc8040db7afae616eda6329ddc8ef73afc8bcb611bf9126937970bca83/pip-requirements-parser-31.2.0.tar.gz",
+          "sha256": "8c2a6f8e091ac2693824a5ef4e3b250226e34f74a20a91a87b9ab0714b47788f",
+          "md5": "a202d8dda5f2840181b80d4c81fa63d0",
+          "size": 209659,
+          "filename": "pip-requirements-parser-31.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2053,7 +2221,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/90/8d/09cc1c99a30ac14050fc4e04e549e024be83ff72a7f63e75023501baf977/pkginfo2-30.0.0.tar.gz",
+          "sha256": "5e1afbeb156febb407a9b5c16b51c5b4737c529eeda2b1607e1e277cf260669c",
+          "md5": "8fd5bd0d69938534c9796195164b5928",
+          "size": 364071,
+          "filename": "pkginfo2-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2117,7 +2293,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz",
+          "sha256": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+          "md5": "fadc2f3bf5872bf6310576a86c3566e0",
+          "size": 1999906,
+          "filename": "pyparsing-3.0.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2170,7 +2354,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/yaml/pyyaml/issues",
       "code_view_url": "https://github.com/yaml/pyyaml",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/yaml/pyyaml.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2182,7 +2366,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+          "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+          "md5": "1d19c798f25e58e3e582f0f8c977dbb8",
+          "size": 124996,
+          "filename": "PyYAML-6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2238,7 +2430,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2250,7 +2442,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz",
+          "sha256": "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+          "md5": "bcc01b73974a305cc7c5b092e7d07004",
+          "size": 106758,
+          "filename": "requests-2.27.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2308,7 +2508,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/20/9541749d77aebf66dd92e2b803f38a50e3a5c76e7876f45eb2b37e758d82/resolvelib-0.8.1.tar.gz",
+          "sha256": "c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+          "md5": "fbd5fbcac181644333390ea6a71c4edc",
+          "size": 17308,
+          "filename": "resolvelib-0.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2362,7 +2570,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/4a/7374cac103bdfec7c199606784119bee9171ba051290b219ffec1bedc650/saneyaml-0.5.2.tar.gz",
+          "sha256": "d6074f1959041342ab41d74a6f904720ffbcf63c94467858e0e22e17e3c43d41",
+          "md5": "4985d7a8f4ad5af6ae53132e8d23a247",
+          "size": 32034,
+          "filename": "saneyaml-0.5.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2430,7 +2646,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/03/bac179d539362319b4779a00764e95f7542f4920084163db6b0fd4742d38/soupsieve-2.3.2.post1.tar.gz",
+          "sha256": "fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d",
+          "md5": "4c824620563604cbf783de149c8b8889",
+          "size": 102814,
+          "filename": "soupsieve-2.3.2.post1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2496,7 +2720,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz",
+          "sha256": "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93",
+          "md5": "53a0a6c5aef8f5eb5834e78e0fdf0499",
+          "size": 76885,
+          "filename": "text-unidecode-1.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2563,7 +2795,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+          "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+          "md5": "59bce5d8d67e858735ec3f399ec90253",
+          "size": 22253,
+          "filename": "toml-0.10.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2636,7 +2876,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b1/5a/8b5fbb891ef3f81fc923bf3cb4a578c0abf9471eb50ce0f51c74212182ab/typing_extensions-4.1.1.tar.gz",
+          "sha256": "1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+          "md5": "3cd9b7b9a465afbcca8548e11668ca64",
+          "size": 26694,
+          "filename": "typing_extensions-4.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2695,7 +2943,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bf/9b/2bf84e841575b633d8d91ad923e198a415e3901f228715524689495b4317/typing-3.6.6.tar.gz",
+          "sha256": "4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
+          "md5": "64614206b4bdc0864fc0e0bccd69efc9",
+          "size": 71799,
+          "filename": "typing-3.6.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2752,7 +3008,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2764,7 +3020,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/a5/4eab74853625505725cefdf168f48661b2cd04e7843ab836f3f63abf81da/urllib3-1.26.9.tar.gz",
+          "sha256": "aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e",
+          "md5": "d4b58522821a33c5e421191b83e0dbac",
+          "size": 295258,
+          "filename": "urllib3-1.26.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2817,7 +3081,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/02/bf/0d03dbdedb83afec081fefe86cae3a2447250ef1a81ac601a9a56e785401/zipp-3.6.0.tar.gz",
+          "sha256": "71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+          "md5": "8d5cf6eb3270384ae13a6440797ea564",
+          "size": 13047,
+          "filename": "zipp-3.6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/pinned-requirements.txt-expected.json
+++ b/tests/data/pinned-requirements.txt-expected.json
@@ -753,7 +753,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/22/11/fb1a48393106b470fc05450a01317f22ca128541d5c5f755ce092ffaebd0/aboutcode-toolkit-7.0.2.tar.gz",
+          "sha256": "b0bc22ff777187adf5ac50ceb81b3e44dcbf9d7239ecf8b1a80a1ac1ac87a2b5",
+          "md5": "b29726a260d0da5c09caf5f07646d766",
+          "size": 380081,
+          "filename": "aboutcode-toolkit-7.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -818,7 +826,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-attrs/attrs/issues",
       "code_view_url": "https://github.com/python-attrs/attrs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-attrs/attrs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -830,7 +838,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d7/77/ebb15fc26d0f815839ecd897b919ed6d85c050feeb83e100e020df9153d2/attrs-21.4.0.tar.gz",
+          "sha256": "626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd",
+          "md5": "5a9b5e9ceebc380a13fb93235b11bbda",
+          "size": 201839,
+          "filename": "attrs-21.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -888,7 +904,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e8/b0/cd2b968000577ec5ce6c741a54d846dfa402372369b8b6861720aa9ecea7/beautifulsoup4-4.11.1.tar.gz",
+          "sha256": "ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693",
+          "md5": "22f22f89cf9da41b22e1ece9639c66a3",
+          "size": 517113,
+          "filename": "beautifulsoup4-4.11.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -948,7 +972,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a2/d9/b6e56a303d221fc0bdff2c775e4eef7fedd58194aa5a96fa89fb71634cc9/boolean.py-4.0.tar.gz",
+          "sha256": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4",
+          "md5": "5a8b0eae254b0c37a1bdde38c6bd5b5d",
+          "size": 34504,
+          "filename": "boolean.py-4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -996,7 +1028,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1008,7 +1040,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz",
+          "sha256": "9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
+          "md5": "70f3688480b8fc4556c033f3ea655d36",
+          "size": 156701,
+          "filename": "certifi-2022.5.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1083,7 +1123,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz",
+          "sha256": "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+          "md5": "f6664e0e90dbb3cc9cfc154a980f9864",
+          "size": 79105,
+          "filename": "charset-normalizer-2.0.12.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1132,7 +1180,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/click/issues/",
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1144,7 +1192,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/cf/706c1ad49ab26abed0b77a2f867984c1341ed7387b8030a6aa914e2942a0/click-8.0.4.tar.gz",
+          "sha256": "8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb",
+          "md5": "c89efc98d1b36d52ba26a39c803df0cc",
+          "size": 329520,
+          "filename": "click-8.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1217,7 +1273,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz",
+          "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+          "md5": "57b22f2597f63df051b69906fbf310cc",
+          "size": 27813,
+          "filename": "colorama-0.4.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1272,7 +1336,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/8b/65/99ad49681e8897ab851014f18bf51e8081a492efc1ef0b443209f7a83e0e/commoncode-30.2.0.tar.gz",
+          "sha256": "ee470359fc3833b6e87b40013b8a1bd5df973b56314bddb89ad1844ef1e835fd",
+          "md5": "754bc02c505adcf65a8d1006b7894703",
+          "size": 1690459,
+          "filename": "commoncode-30.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1332,7 +1404,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2d/a3/49cd39abdf8b4832cba27d635a775b721388e50671bee7ea0d10afcf0cfd/dparse2-0.6.1.tar.gz",
+          "sha256": "fbafb839c3dc83040012af2602a00ca4e4b1693a9b1988492150466afa59dd26",
+          "md5": "8d8c7be322b2211c5c5eea6150da2832",
+          "size": 10458,
+          "filename": "dparse2-0.6.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1381,7 +1461,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/et_xmfile/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/et_xmlfile",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/et_xmlfile.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1393,7 +1473,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz",
+          "sha256": "dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54",
+          "md5": "d7db773c110c5534e61f288fdfcad807",
+          "size": 17234,
+          "filename": "et_xmlfile-2.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1461,7 +1549,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz",
+          "sha256": "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
+          "md5": "5856306eac5f25db8249e37a4c6ee3e7",
+          "size": 286689,
+          "filename": "idna-3.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1514,7 +1610,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/85/ed/e65128cc5cb1580f22ee3009d9187ecdfcc43ffb3b581fe854b24e87d8e7/importlib_metadata-4.8.3.tar.gz",
+          "sha256": "766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668",
+          "md5": "833c41fd427678c8b590c5a7818dd873",
+          "size": 41979,
+          "filename": "importlib_metadata-4.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1572,7 +1676,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f8/80/81bf8129a2cc012a225ea0dc39cd6e11531a61d115616b1eead33b157164/intbitset-3.0.1.tar.gz",
+          "sha256": "f1e6d03c6729922a223c51849df65b9e916e625aefb911784e7f9acd4c207d53",
+          "md5": "8f417e4ec5879841fde7aa873320ffdc",
+          "size": 151831,
+          "filename": "intbitset-3.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1618,7 +1730,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1629,7 +1741,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1691,7 +1811,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/57/8b/dbe230196eee2de208ba87dcfae69c46db9d7ed70e2f30f143bf994ee075/license_expression-30.3.1.tar.gz",
+          "sha256": "60d5bec1f3364c256a92b9a08583d7ea933c7aa272c8d36d04144a89a3858c01",
+          "md5": "030df78064748876ca852e8b5ac0d407",
+          "size": 174601,
+          "filename": "license_expression-30.3.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1736,7 +1864,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/markupsafe/issues/",
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1748,7 +1876,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
+          "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+          "md5": "8fe7227653f2fb9b1ffe7f9f2058998a",
+          "size": 19384,
+          "filename": "MarkupSafe-2.1.5.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1797,7 +1933,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/openpyxl/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/openpyxl",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/openpyxl.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1809,7 +1945,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz",
+          "sha256": "cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050",
+          "md5": "13e63bdced2dbca00c8741eea3ecfa1c",
+          "size": 186464,
+          "filename": "openpyxl-3.1.5.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1874,7 +2018,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6e/ee/8d89d660da6e44d77f547de9949b380dc93b08b758ee361bc237bcc8b179/packageurl-python-0.9.9.tar.gz",
+          "sha256": "872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09",
+          "md5": "35651efef038a54f5083197038d358c0",
+          "size": 30107,
+          "filename": "packageurl-python-0.9.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1937,7 +2089,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz",
+          "sha256": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+          "md5": "e713c1939f294fd729af4a7be40dd141",
+          "size": 84848,
+          "filename": "packaging-21.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1991,7 +2151,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fc/aa/4fbc8040db7afae616eda6329ddc8ef73afc8bcb611bf9126937970bca83/pip-requirements-parser-31.2.0.tar.gz",
+          "sha256": "8c2a6f8e091ac2693824a5ef4e3b250226e34f74a20a91a87b9ab0714b47788f",
+          "md5": "a202d8dda5f2840181b80d4c81fa63d0",
+          "size": 209659,
+          "filename": "pip-requirements-parser-31.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2053,7 +2221,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/90/8d/09cc1c99a30ac14050fc4e04e549e024be83ff72a7f63e75023501baf977/pkginfo2-30.0.0.tar.gz",
+          "sha256": "5e1afbeb156febb407a9b5c16b51c5b4737c529eeda2b1607e1e277cf260669c",
+          "md5": "8fd5bd0d69938534c9796195164b5928",
+          "size": 364071,
+          "filename": "pkginfo2-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2117,7 +2293,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz",
+          "sha256": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+          "md5": "fadc2f3bf5872bf6310576a86c3566e0",
+          "size": 1999906,
+          "filename": "pyparsing-3.0.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2170,7 +2354,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/yaml/pyyaml/issues",
       "code_view_url": "https://github.com/yaml/pyyaml",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/yaml/pyyaml.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2182,7 +2366,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+          "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+          "md5": "1d19c798f25e58e3e582f0f8c977dbb8",
+          "size": 124996,
+          "filename": "PyYAML-6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2238,7 +2430,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2250,7 +2442,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz",
+          "sha256": "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+          "md5": "bcc01b73974a305cc7c5b092e7d07004",
+          "size": 106758,
+          "filename": "requests-2.27.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2308,7 +2508,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/20/9541749d77aebf66dd92e2b803f38a50e3a5c76e7876f45eb2b37e758d82/resolvelib-0.8.1.tar.gz",
+          "sha256": "c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+          "md5": "fbd5fbcac181644333390ea6a71c4edc",
+          "size": 17308,
+          "filename": "resolvelib-0.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2362,7 +2570,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/4a/7374cac103bdfec7c199606784119bee9171ba051290b219ffec1bedc650/saneyaml-0.5.2.tar.gz",
+          "sha256": "d6074f1959041342ab41d74a6f904720ffbcf63c94467858e0e22e17e3c43d41",
+          "md5": "4985d7a8f4ad5af6ae53132e8d23a247",
+          "size": 32034,
+          "filename": "saneyaml-0.5.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2430,7 +2646,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/03/bac179d539362319b4779a00764e95f7542f4920084163db6b0fd4742d38/soupsieve-2.3.2.post1.tar.gz",
+          "sha256": "fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d",
+          "md5": "4c824620563604cbf783de149c8b8889",
+          "size": 102814,
+          "filename": "soupsieve-2.3.2.post1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2496,7 +2720,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz",
+          "sha256": "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93",
+          "md5": "53a0a6c5aef8f5eb5834e78e0fdf0499",
+          "size": 76885,
+          "filename": "text-unidecode-1.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2563,7 +2795,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+          "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+          "md5": "59bce5d8d67e858735ec3f399ec90253",
+          "size": 22253,
+          "filename": "toml-0.10.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2636,7 +2876,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b1/5a/8b5fbb891ef3f81fc923bf3cb4a578c0abf9471eb50ce0f51c74212182ab/typing_extensions-4.1.1.tar.gz",
+          "sha256": "1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+          "md5": "3cd9b7b9a465afbcca8548e11668ca64",
+          "size": 26694,
+          "filename": "typing_extensions-4.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2695,7 +2943,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bf/9b/2bf84e841575b633d8d91ad923e198a415e3901f228715524689495b4317/typing-3.6.6.tar.gz",
+          "sha256": "4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
+          "md5": "64614206b4bdc0864fc0e0bccd69efc9",
+          "size": 71799,
+          "filename": "typing-3.6.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2752,7 +3008,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2764,7 +3020,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/a5/4eab74853625505725cefdf168f48661b2cd04e7843ab836f3f63abf81da/urllib3-1.26.9.tar.gz",
+          "sha256": "aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e",
+          "md5": "d4b58522821a33c5e421191b83e0dbac",
+          "size": 295258,
+          "filename": "urllib3-1.26.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2817,7 +3081,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/02/bf/0d03dbdedb83afec081fefe86cae3a2447250ef1a81ac601a9a56e785401/zipp-3.6.0.tar.gz",
+          "sha256": "71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+          "md5": "8d5cf6eb3270384ae13a6440797ea564",
+          "size": 13047,
+          "filename": "zipp-3.6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/prefer-source-expected.json
+++ b/tests/data/prefer-source-expected.json
@@ -61,7 +61,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz",
+          "sha256": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+          "md5": "8864ff5ed01cd28755cc87f1443dbc67",
+          "size": 13344,
+          "filename": "zipp-3.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/resolved_deps/autobahn-310-expected.json
+++ b/tests/data/resolved_deps/autobahn-310-expected.json
@@ -24,11 +24,11 @@
     {
       "package": "pkg:pypi/hyperlink@21.0.0",
       "dependencies": [
-        "pkg:pypi/idna@3.15"
+        "pkg:pypi/idna@3.16"
       ]
     },
     {
-      "package": "pkg:pypi/idna@3.15",
+      "package": "pkg:pypi/idna@3.16",
       "dependencies": []
     },
     {
@@ -49,7 +49,7 @@
     "pkg:pypi/cffi@2.0.0",
     "pkg:pypi/cryptography@43.0.3",
     "pkg:pypi/hyperlink@21.0.0",
-    "pkg:pypi/idna@3.15",
+    "pkg:pypi/idna@3.16",
     "pkg:pypi/pycparser@2.23",
     "pkg:pypi/setuptools@82.0.1",
     "pkg:pypi/txaio@23.6.1"

--- a/tests/data/resolved_deps/flask-310-expected.json
+++ b/tests/data/resolved_deps/flask-310-expected.json
@@ -1,13 +1,13 @@
 [
   [
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
       "package": "pkg:pypi/flask@2.1.2",
       "dependencies": [
-        "pkg:pypi/click@8.4.0",
+        "pkg:pypi/click@8.4.1",
         "pkg:pypi/itsdangerous@2.2.0",
         "pkg:pypi/jinja2@3.1.6",
         "pkg:pypi/werkzeug@3.1.8"
@@ -35,7 +35,7 @@
     }
   ],
   [
-    "pkg:pypi/click@8.4.0",
+    "pkg:pypi/click@8.4.1",
     "pkg:pypi/flask@2.1.2",
     "pkg:pypi/itsdangerous@2.2.0",
     "pkg:pypi/jinja2@3.1.6",

--- a/tests/data/resolved_deps/flask-310-win-expected.json
+++ b/tests/data/resolved_deps/flask-310-win-expected.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": [
         "pkg:pypi/colorama@0.4.6"
       ]
@@ -13,7 +13,7 @@
     {
       "package": "pkg:pypi/flask@2.1.2",
       "dependencies": [
-        "pkg:pypi/click@8.4.0",
+        "pkg:pypi/click@8.4.1",
         "pkg:pypi/itsdangerous@2.2.0",
         "pkg:pypi/jinja2@3.1.6",
         "pkg:pypi/werkzeug@3.1.8"
@@ -41,7 +41,7 @@
     }
   ],
   [
-    "pkg:pypi/click@8.4.0",
+    "pkg:pypi/click@8.4.1",
     "pkg:pypi/colorama@0.4.6",
     "pkg:pypi/flask@2.1.2",
     "pkg:pypi/itsdangerous@2.2.0",

--- a/tests/data/setup/simple-setup.py-expected.json
+++ b/tests/data/setup/simple-setup.py-expected.json
@@ -131,7 +131,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a1/eb/b37ef5647243ade8308f7bb46b1a45e6204790c163cbd8cf6df990d5c1c1/boolean.py-3.8.tar.gz",
+          "sha256": "cc24e20f985d60cd4a3a5a1c0956dd12611159d32a75081dabd0c9ab981acaa4",
+          "md5": "83ccc145ba74a585637124c8bc648333",
+          "size": 32196,
+          "filename": "boolean.py-3.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -200,7 +208,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/27/71/a8d8d78f7866a75f6a940cc53d1557a5edf1ae4a281fe8797cf36077105d/license-expression-1.0.tar.gz",
+          "sha256": "8aaa455c5b97c4f2174090178b19792b2a1c620e80591aafd4e0a99b713f9e8d",
+          "md5": "81477f779099f55071c6a7b88a29bb01",
+          "size": 53559,
+          "filename": "license-expression-1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/setup/spdx-setup.py-expected.json
+++ b/tests/data/setup/spdx-setup.py-expected.json
@@ -169,7 +169,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/40/32ce777053517be3032bb2ab3bb216959071ee0c16c761879e75c34a323e/isodate-0.7.0.tar.gz",
+          "sha256": "c6332cf456314b85cc3b6ea2c45a6fa417cb1fddb361f6d2ed8f4f69e843c6d1",
+          "md5": "06c2886cc00cdfc4ec1f36c1d590bc06",
+          "size": 29597,
+          "filename": "isodate-0.7.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -218,7 +226,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz",
+          "sha256": "00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+          "md5": "6465f602e656455affcd7c5734c638f8",
+          "size": 159130,
+          "filename": "ply-3.11.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -283,7 +299,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz",
+          "sha256": "c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+          "md5": "f0953e47a0112f7a65aec2305ffdf7b4",
+          "size": 649718,
+          "filename": "pyparsing-2.4.7.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -351,7 +375,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2f/ae/a50934a7ed4f9d80bbc0e0cf725c7fd2208f2e433efbf881ed0c0317a7f1/rdflib-5.0.0.tar.gz",
+          "sha256": "78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155",
+          "md5": "80d7c6adc2e4040cdd8dade2e0e61403",
+          "size": 818586,
+          "filename": "rdflib-5.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -407,7 +439,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz",
+          "sha256": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+          "md5": "a0387fe15662c71057b4fb2b7aa9056a",
+          "size": 34031,
+          "filename": "six-1.17.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/single-url-env-var-expected.json
+++ b/tests/data/single-url-env-var-expected.json
@@ -60,7 +60,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz",
+          "sha256": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+          "md5": "8864ff5ed01cd28755cc87f1443dbc67",
+          "size": 13344,
+          "filename": "zipp-3.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/single-url-except-simple-expected.json
+++ b/tests/data/single-url-except-simple-expected.json
@@ -56,7 +56,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets-eco/blinker/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets-eco/blinker.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -67,13 +67,79 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1e/57/a6a1721eff09598fb01f3c7cda070c1b6a0f12d63c83236edf79a440abcc/blinker-1.8.2.tar.gz",
+          "sha256": "8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83",
+          "md5": "ce2f9fb3bc0c0000db11f012f5f5afda",
+          "size": 23161,
+          "filename": "blinker-1.8.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
       "api_data_url": "https://pypi.org/pypi/blinker/1.8.2/json",
       "datasource_id": null,
       "purl": "pkg:pypi/blinker@1.8.2"
+    },
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "click",
+      "version": "8.3.1",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
+      "release_date": "2025-11-15T20:45:41",
+      "parties": [
+        {
+          "type": "person",
+          "role": "maintainer",
+          "name": null,
+          "email": "Pallets <contact@palletsprojects.com>",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Typing :: Typed"
+      ],
+      "homepage_url": null,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/click-8.3.1-py3-none-any.whl",
+      "size": 108274,
+      "sha1": null,
+      "md5": "f032502934a5979330da77e3f09d889c",
+      "sha256": "981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6",
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": "https://github.com/pallets/click/",
+      "vcs_url": "https://github.com/pallets/click.git",
+      "copyright": null,
+      "license_expression": "BSD-3-Clause",
+      "declared_license": {},
+      "notice_text": null,
+      "source_packages": [],
+      "file_references": [],
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz",
+          "sha256": "12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
+          "md5": "5f89d725a424b101607ec40927f78773",
+          "size": 295065,
+          "filename": "click-8.3.1.tar.gz"
+        }
+      },
+      "dependencies": [],
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/click/8.3.1/json",
+      "datasource_id": null,
+      "purl": "pkg:pypi/click@8.3.1"
     },
     {
       "type": "pypi",
@@ -116,7 +182,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -127,13 +193,78 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/41/e1/d104c83026f8d35dfd2c261df7d64738341067526406b40190bc063e829a/flask-3.0.3.tar.gz",
+          "sha256": "ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842",
+          "md5": "4658b022a07f6d8df51ef24c717fe162",
+          "size": 676315,
+          "filename": "flask-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
       "api_data_url": "https://pypi.org/pypi/flask/3.0.3/json",
       "datasource_id": null,
       "purl": "pkg:pypi/flask@3.0.3"
+    },
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "importlib-metadata",
+      "version": "8.7.1",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "Read metadata from Python packages\n.. image:: https://img.shields.io/pypi/v/importlib_metadata.svg\n   :target: https://pypi.org/project/importlib_metadata\n\n.. image:: https://img.shields.io/pypi/pyversions/importlib_metadata.svg\n\n.. image:: https://github.com/python/importlib_metadata/actions/workflows/main.yml/badge.svg\n   :target: https://github.com/python/importlib_metadata/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json\n    :target: https://github.com/astral-sh/ruff\n    :alt: Ruff\n\n.. image:: https://readthedocs.org/projects/importlib-metadata/badge/?version=latest\n   :target: https://importlib-metadata.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2025-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/importlib-metadata\n   :target: https://tidelift.com/subscription/pkg/pypi-importlib-metadata?utm_source=pypi-importlib-metadata&utm_medium=readme\n\nLibrary to access the metadata for a Python package.\n\nThis package supplies third-party access to the functionality of\n`importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_\nincluding improvements added to subsequent Python versions.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - importlib_metadata\n     - stdlib\n   * - 7.0\n     - 3.13\n   * - 6.5\n     - 3.12\n   * - 4.13\n     - 3.11\n   * - 4.6\n     - 3.10\n   * - 1.4\n     - 3.8\n\n\nUsage\n=====\n\nSee the `online documentation <https://importlib-metadata.readthedocs.io/>`_\nfor usage details.\n\n`Finder authors\n<https://docs.python.org/3/reference/import.html#finders-and-loaders>`_ can\nalso add support for custom package installers.  See the above documentation\nfor details.\n\n\nCaveats\n=======\n\nThis project primarily supports third-party packages installed by PyPA\ntools (or other conforming packages). It does not support:\n\n- Packages in the stdlib.\n- Packages installed without metadata.\n\nProject details\n===============\n\n * Project home: https://github.com/python/importlib_metadata\n * Report bugs at: https://github.com/python/importlib_metadata/issues\n * Code hosting: https://github.com/python/importlib_metadata\n * Documentation: https://importlib-metadata.readthedocs.io/\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-importlib-metadata?utm_source=pypi-importlib-metadata&utm_medium=referral&utm_campaign=github>`_.",
+      "release_date": "2025-12-21T10:00:18",
+      "parties": [
+        {
+          "type": "person",
+          "role": "author",
+          "name": null,
+          "email": "\"Jason R. Coombs\" <jaraco@jaraco.com>",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only"
+      ],
+      "homepage_url": null,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/importlib_metadata-8.7.1-py3-none-any.whl",
+      "size": 27865,
+      "sha1": null,
+      "md5": "17518a8b7a8a452aa0fc16b98333a468",
+      "sha256": "5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151",
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": "https://github.com/python/importlib_metadata",
+      "vcs_url": "https://github.com/python/importlib_metadata.git",
+      "copyright": null,
+      "license_expression": "Apache-2.0",
+      "declared_license": {},
+      "notice_text": null,
+      "source_packages": [],
+      "file_references": [],
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz",
+          "sha256": "49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb",
+          "md5": "4edb62e77e945bf4b898ea6427dcc7bd",
+          "size": 57107,
+          "filename": "importlib_metadata-8.7.1.tar.gz"
+        }
+      },
+      "dependencies": [],
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/importlib-metadata/8.7.1/json",
+      "datasource_id": null,
+      "purl": "pkg:pypi/importlib-metadata@8.7.1"
     },
     {
       "type": "pypi",
@@ -170,7 +301,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -181,13 +312,147 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz",
+          "sha256": "e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173",
+          "md5": "a901babde35694c3577f7655010cd380",
+          "size": 54410,
+          "filename": "itsdangerous-2.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
       "api_data_url": "https://pypi.org/pypi/itsdangerous/2.2.0/json",
       "datasource_id": null,
       "purl": "pkg:pypi/itsdangerous@2.2.0"
+    },
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "jinja2",
+      "version": "3.1.6",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "A very fast and expressive template engine.\n# Jinja\n\nJinja is a fast, expressive, extensible templating engine. Special\nplaceholders in the template allow writing code similar to Python\nsyntax. Then the template is passed data to render the final document.\n\nIt includes:\n\n-   Template inheritance and inclusion.\n-   Define and import macros within templates.\n-   HTML templates can use autoescaping to prevent XSS from untrusted\n    user input.\n-   A sandboxed environment can safely render untrusted templates.\n-   AsyncIO support for generating templates and calling async\n    functions.\n-   I18N support with Babel.\n-   Templates are compiled to optimized Python code just-in-time and\n    cached, or can be compiled ahead-of-time.\n-   Exceptions point to the correct line in templates to make debugging\n    easier.\n-   Extensible filters, tests, functions, and even syntax.\n\nJinja's philosophy is that while application logic belongs in Python if\npossible, it shouldn't make the template designer's job difficult by\nrestricting functionality too much.\n\n\n## In A Nutshell\n\n```jinja\n{% extends \"base.html\" %}\n{% block title %}Members{% endblock %}\n{% block content %}\n  <ul>\n  {% for user in users %}\n    <li><a href=\"{{ user.url }}\">{{ user.username }}</a></li>\n  {% endfor %}\n  </ul>\n{% endblock %}\n```\n\n## Donate\n\nThe Pallets organization develops and supports Jinja and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
+      "release_date": "2025-03-05T20:05:00",
+      "parties": [
+        {
+          "type": "person",
+          "role": "maintainer",
+          "name": null,
+          "email": "Pallets <contact@palletsprojects.com>",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Topic :: Text Processing :: Markup :: HTML",
+        "Typing :: Typed"
+      ],
+      "homepage_url": null,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/jinja2-3.1.6-py3-none-any.whl",
+      "size": 134899,
+      "sha1": null,
+      "md5": "845b37cea56edd0f4dbd949244e9d798",
+      "sha256": "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67",
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": "https://github.com/pallets/jinja/",
+      "vcs_url": "https://github.com/pallets/jinja.git",
+      "copyright": null,
+      "license_expression": null,
+      "declared_license": {
+        "classifiers": [
+          "License :: OSI Approved :: BSD License"
+        ]
+      },
+      "notice_text": null,
+      "source_packages": [],
+      "file_references": [],
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
+      "dependencies": [],
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/jinja2/3.1.6/json",
+      "datasource_id": null,
+      "purl": "pkg:pypi/jinja2@3.1.6"
+    },
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "markupsafe",
+      "version": "3.0.3",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "Safely add untrusted strings to HTML/XML markup.\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/markupsafe/refs/heads/stable/docs/_static/markupsafe-name.svg\" alt=\"\" height=\"150\"></div>\n\n# MarkupSafe\n\nMarkupSafe implements a text object that escapes characters so it is\nsafe to use in HTML and XML. Characters that have special meanings are\nreplaced so that they display as the actual characters. This mitigates\ninjection attacks, meaning untrusted user input can safely be displayed\non a page.\n\n\n## Examples\n\n```pycon\n>>> from markupsafe import Markup, escape\n\n>>> # escape replaces special characters and wraps in Markup\n>>> escape(\"<script>alert(document.cookie);</script>\")\nMarkup('&lt;script&gt;alert(document.cookie);&lt;/script&gt;')\n\n>>> # wrap in Markup to mark text \"safe\" and prevent escaping\n>>> Markup(\"<strong>Hello</strong>\")\nMarkup('<strong>hello</strong>')\n\n>>> escape(Markup(\"<strong>Hello</strong>\"))\nMarkup('<strong>hello</strong>')\n\n>>> # Markup is a str subclass\n>>> # methods and operators escape their arguments\n>>> template = Markup(\"Hello <em>{name}</em>\")\n>>> template.format(name='\"World\"')\nMarkup('Hello <em>&#34;World&#34;</em>')\n```\n\n## Donate\n\nThe Pallets organization develops and supports MarkupSafe and other\npopular packages. In order to grow the community of contributors and\nusers, and allow the maintainers to devote more time to the projects,\n[please donate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
+      "release_date": "2025-09-27T18:37:40",
+      "parties": [
+        {
+          "type": "person",
+          "role": "maintainer",
+          "name": null,
+          "email": "Pallets <contact@palletsprojects.com>",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Topic :: Text Processing :: Markup :: HTML",
+        "Typing :: Typed"
+      ],
+      "homepage_url": null,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/markupsafe-3.0.3.tar.gz",
+      "size": 80313,
+      "sha1": null,
+      "md5": "13a73126d25afa72a1ff0daed072f5fe",
+      "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": "https://github.com/pallets/markupsafe/",
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
+      "copyright": null,
+      "license_expression": "BSD-3-Clause",
+      "declared_license": {},
+      "notice_text": null,
+      "source_packages": [],
+      "file_references": [],
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz",
+          "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+          "md5": "13a73126d25afa72a1ff0daed072f5fe",
+          "size": 80313,
+          "filename": "markupsafe-3.0.3.tar.gz"
+        }
+      },
+      "dependencies": [],
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/markupsafe/3.0.3/json",
+      "datasource_id": null,
+      "purl": "pkg:pypi/markupsafe@3.0.3"
     },
     {
       "type": "pypi",
@@ -230,7 +495,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/werkzeug/issues/",
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -241,13 +506,78 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d4/f9/0ba83eaa0df9b9e9d1efeb2ea351d0677c37d41ee5d0f91e98423c7281c9/werkzeug-3.0.6.tar.gz",
+          "sha256": "a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d",
+          "md5": "0d13f3dbe9b08aecdebe3d9b61cc58aa",
+          "size": 805170,
+          "filename": "werkzeug-3.0.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
       "api_data_url": "https://pypi.org/pypi/werkzeug/3.0.6/json",
       "datasource_id": null,
       "purl": "pkg:pypi/werkzeug@3.0.6"
+    },
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "zipp",
+      "version": "3.23.0",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: https://pypi.org/project/zipp\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n\n.. image:: https://github.com/jaraco/zipp/actions/workflows/main.yml/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json\n    :target: https://github.com/astral-sh/ruff\n    :alt: Ruff\n\n.. image:: https://readthedocs.org/projects/zipp/badge/?version=latest\n..    :target: https://zipp.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2025-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.18\n     - 3.13\n   * - 3.16\n     - 3.12\n   * - 3.5\n     - 3.11\n   * - 3.2\n     - 3.10\n   * - 3.3 ??\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.",
+      "release_date": "2025-06-08T17:06:38",
+      "parties": [
+        {
+          "type": "person",
+          "role": "author",
+          "name": null,
+          "email": "\"Jason R. Coombs\" <jaraco@jaraco.com>",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only"
+      ],
+      "homepage_url": null,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/zipp-3.23.0-py3-none-any.whl",
+      "size": 10276,
+      "sha1": null,
+      "md5": "517d3915cf2576739abd556828f45cc4",
+      "sha256": "071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e",
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": "https://github.com/jaraco/zipp",
+      "vcs_url": "https://github.com/jaraco/zipp.git",
+      "copyright": null,
+      "license_expression": "MIT",
+      "declared_license": {},
+      "notice_text": null,
+      "source_packages": [],
+      "file_references": [],
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz",
+          "sha256": "a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166",
+          "md5": "7565b42f396db31df7e4b3eceff223ad",
+          "size": 25547,
+          "filename": "zipp-3.23.0.tar.gz"
+        }
+      },
+      "dependencies": [],
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/zipp/3.23.0/json",
+      "datasource_id": null,
+      "purl": "pkg:pypi/zipp@3.23.0"
     }
   ],
   "resolved_dependencies_graph": [

--- a/tests/data/single-url-expected.json
+++ b/tests/data/single-url-expected.json
@@ -60,7 +60,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz",
+          "sha256": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+          "md5": "8864ff5ed01cd28755cc87f1443dbc67",
+          "size": 13344,
+          "filename": "zipp-3.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/test-api-expected.json
+++ b/tests/data/test-api-expected.json
@@ -5,12 +5,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -28,28 +28,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -98,7 +106,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -110,7 +118,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -153,7 +169,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -164,7 +180,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz",
+          "sha256": "e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173",
+          "md5": "a901babde35694c3577f7655010cd380",
+          "size": 54410,
+          "filename": "itsdangerous-2.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -210,7 +234,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -221,7 +245,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -267,14 +299,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz",
+          "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+          "md5": "13a73126d25afa72a1ff0daed072f5fe",
+          "size": 80313,
+          "filename": "markupsafe-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -323,14 +363,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz",
+          "sha256": "9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44",
+          "md5": "5b3063a0bfc95d46cb35258b03b9f30e",
+          "size": 875852,
+          "filename": "werkzeug-3.1.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -341,13 +389,13 @@
   ],
   "resolution": [
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
       "package": "pkg:pypi/flask@2.1.2",
       "dependencies": [
-        "pkg:pypi/click@8.4.0",
+        "pkg:pypi/click@8.4.1",
         "pkg:pypi/itsdangerous@2.2.0",
         "pkg:pypi/jinja2@3.1.6",
         "pkg:pypi/werkzeug@3.1.8"

--- a/tests/data/test-api-pdt-expected.json
+++ b/tests/data/test-api-pdt-expected.json
@@ -5,12 +5,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:56",
+      "release_date": "2026-05-22T04:08:35",
       "parties": [
         {
           "type": "person",
@@ -28,28 +28,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-      "size": 116147,
+      "download_url": "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl",
+      "size": 116639,
       "sha1": null,
-      "md5": "7279fa28796316315ed206d95cfe0e3b",
-      "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
+      "md5": "11fc29e641c2af86277efe03ff135fd1",
+      "sha256": "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -98,7 +106,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -110,7 +118,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -153,7 +169,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -164,7 +180,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz",
+          "sha256": "e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173",
+          "md5": "a901babde35694c3577f7655010cd380",
+          "size": 54410,
+          "filename": "itsdangerous-2.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -210,7 +234,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -221,7 +245,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -267,14 +299,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz",
+          "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+          "md5": "13a73126d25afa72a1ff0daed072f5fe",
+          "size": 80313,
+          "filename": "markupsafe-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -323,14 +363,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz",
+          "sha256": "9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44",
+          "md5": "5b3063a0bfc95d46cb35258b03b9f30e",
+          "size": 875852,
+          "filename": "werkzeug-3.1.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -348,7 +396,7 @@
         {
           "key": "click",
           "package_name": "click",
-          "installed_version": "8.4.0",
+          "installed_version": "8.4.1",
           "dependencies": []
         },
         {

--- a/tests/data/test-api-with-partial-setup-py.json
+++ b/tests/data/test-api-with-partial-setup-py.json
@@ -118,7 +118,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz",
+          "sha256": "afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602",
+          "md5": "a0d76b528e489bf7ce1255a0a1486123",
+          "size": 269730,
+          "filename": "semver-3.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/test-api-with-prefer-source.json
+++ b/tests/data/test-api-with-prefer-source.json
@@ -5,12 +5,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:58",
+      "release_date": "2026-05-22T04:08:37",
       "parties": [
         {
           "type": "person",
@@ -28,28 +28,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz",
-      "size": 350843,
+      "download_url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+      "size": 353007,
       "sha1": null,
-      "md5": "e608f374641a50a2e7808a7397cca02d",
-      "sha256": "638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973",
+      "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+      "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -98,7 +106,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -110,7 +118,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -153,7 +169,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -164,7 +180,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz",
+          "sha256": "e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173",
+          "md5": "a901babde35694c3577f7655010cd380",
+          "size": 54410,
+          "filename": "itsdangerous-2.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -210,7 +234,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -221,7 +245,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -267,14 +299,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz",
+          "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+          "md5": "13a73126d25afa72a1ff0daed072f5fe",
+          "size": 80313,
+          "filename": "markupsafe-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -323,14 +363,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz",
+          "sha256": "9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44",
+          "md5": "5b3063a0bfc95d46cb35258b03b9f30e",
+          "size": 875852,
+          "filename": "werkzeug-3.1.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -341,13 +389,13 @@
   ],
   "resolution": [
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
       "package": "pkg:pypi/flask@2.1.2",
       "dependencies": [
-        "pkg:pypi/click@8.4.0",
+        "pkg:pypi/click@8.4.1",
         "pkg:pypi/itsdangerous@2.2.0",
         "pkg:pypi/jinja2@3.1.6",
         "pkg:pypi/werkzeug@3.1.8"

--- a/tests/data/test-api-with-python-311.json
+++ b/tests/data/test-api-with-python-311.json
@@ -5,12 +5,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "click",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Composable command line interface toolkit\n<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/click/refs/heads/stable/docs/_static/click-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Click\n\nClick is a Python package for creating beautiful command line interfaces\nin a composable way with as little code as necessary. It's the \"Command\nLine Interface Creation Kit\". It's highly configurable but comes with\nsensible defaults out of the box.\n\nIt aims to make the process of writing command line tools quick and fun\nwhile also preventing any frustration caused by the inability to\nimplement an intended CLI API.\n\nClick in three points:\n\n-   Arbitrary nesting of commands\n-   Automatic help page generation\n-   Supports lazy loading of subcommands at runtime\n\n\n## A Simple Example\n\n```python\nimport click\n\n@click.command()\n@click.option(\"--count\", default=1, help=\"Number of greetings.\")\n@click.option(\"--name\", prompt=\"Your name\", help=\"The person to greet.\")\ndef hello(count, name):\n    \"\"\"Simple program that greets NAME for a total of COUNT times.\"\"\"\n    for _ in range(count):\n        click.echo(f\"Hello, {name}!\")\n\nif __name__ == '__main__':\n    hello()\n```\n\n```\n$ python hello.py --count=3\nYour name: Click\nHello, Click!\nHello, Click!\nHello, Click!\n```\n\n\n## Donate\n\nThe Pallets organization develops and supports Click and other popular\npackages. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today][].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/",
-      "release_date": "2026-05-17T00:47:58",
+      "release_date": "2026-05-22T04:08:37",
       "parties": [
         {
           "type": "person",
@@ -28,28 +28,36 @@
         "Typing :: Typed"
       ],
       "homepage_url": null,
-      "download_url": "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz",
-      "size": 350843,
+      "download_url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+      "size": 353007,
       "sha1": null,
-      "md5": "e608f374641a50a2e7808a7397cca02d",
-      "sha256": "638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973",
+      "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+      "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz",
+          "sha256": "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96",
+          "md5": "28bc070cf89b06d88bf74b2d3c4debc7",
+          "size": 353007,
+          "filename": "click-8.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/click/8.4.0/json",
+      "api_data_url": "https://pypi.org/pypi/click/8.4.1/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/click@8.4.0"
+      "purl": "pkg:pypi/click@8.4.1"
     },
     {
       "type": "pypi",
@@ -98,7 +106,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -110,7 +118,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -153,7 +169,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -164,7 +180,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz",
+          "sha256": "e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173",
+          "md5": "a901babde35694c3577f7655010cd380",
+          "size": 54410,
+          "filename": "itsdangerous-2.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -210,7 +234,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -221,7 +245,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz",
+          "sha256": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+          "md5": "66d4c25ff43d1deaf9637ccda523dec8",
+          "size": 245115,
+          "filename": "jinja2-3.1.6.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -267,14 +299,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz",
+          "sha256": "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+          "md5": "13a73126d25afa72a1ff0daed072f5fe",
+          "size": 80313,
+          "filename": "markupsafe-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -323,14 +363,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": "BSD-3-Clause",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz",
+          "sha256": "9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44",
+          "md5": "5b3063a0bfc95d46cb35258b03b9f30e",
+          "size": 875852,
+          "filename": "werkzeug-3.1.8.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -341,13 +389,13 @@
   ],
   "resolution": [
     {
-      "package": "pkg:pypi/click@8.4.0",
+      "package": "pkg:pypi/click@8.4.1",
       "dependencies": []
     },
     {
       "package": "pkg:pypi/flask@2.1.2",
       "dependencies": [
-        "pkg:pypi/click@8.4.0",
+        "pkg:pypi/click@8.4.1",
         "pkg:pypi/itsdangerous@2.2.0",
         "pkg:pypi/jinja2@3.1.6",
         "pkg:pypi/werkzeug@3.1.8"

--- a/tests/data/test-api-with-recursive-requirement-file.json
+++ b/tests/data/test-api-with-recursive-requirement-file.json
@@ -157,7 +157,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/yaml/pyyaml/issues",
       "code_view_url": "https://github.com/yaml/pyyaml",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/yaml/pyyaml.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -169,7 +169,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+          "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+          "md5": "1d19c798f25e58e3e582f0f8c977dbb8",
+          "size": 124996,
+          "filename": "PyYAML-6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -230,7 +238,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz",
+          "sha256": "08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b",
+          "md5": "2a126aeef8b21324ecdeac15ff46ef17",
+          "size": 10890,
+          "filename": "retrying-1.3.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -300,7 +316,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/42/f3/0e1bc2c4f15e05e30c6b99322b9ddaa2babb3f43bc7df2698efdc1553439/Shapely-1.7.1.tar.gz",
+          "sha256": "1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129",
+          "md5": "2bf7bc1199b3a88b13c12109cd3d2429",
+          "size": 383194,
+          "filename": "Shapely-1.7.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -358,7 +382,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/62/de/a75c0c8341a2edd186e14648c231c92c9e672dd38c544089615140c28ac6/simplekml-1.3.5.tar.gz",
+          "sha256": "657b4e20177299a4e80bacfafff1f91102010bc23dc0ce7a7ae43bdd4246049e",
+          "md5": "23f9cf9efa5e08981b7b004ce0ce5cb3",
+          "size": 39069,
+          "filename": "simplekml-1.3.5.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -414,7 +446,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz",
+          "sha256": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+          "md5": "a0387fe15662c71057b4fb2b7aa9056a",
+          "size": 34031,
+          "filename": "six-1.17.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/test-api-with-requirement-file.json
+++ b/tests/data/test-api-with-requirement-file.json
@@ -1537,7 +1537,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/22/11/fb1a48393106b470fc05450a01317f22ca128541d5c5f755ce092ffaebd0/aboutcode-toolkit-7.0.2.tar.gz",
+          "sha256": "b0bc22ff777187adf5ac50ceb81b3e44dcbf9d7239ecf8b1a80a1ac1ac87a2b5",
+          "md5": "b29726a260d0da5c09caf5f07646d766",
+          "size": 380081,
+          "filename": "aboutcode-toolkit-7.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1602,7 +1610,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/python-attrs/attrs/issues",
       "code_view_url": "https://github.com/python-attrs/attrs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/python-attrs/attrs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1614,7 +1622,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d7/77/ebb15fc26d0f815839ecd897b919ed6d85c050feeb83e100e020df9153d2/attrs-21.4.0.tar.gz",
+          "sha256": "626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd",
+          "md5": "5a9b5e9ceebc380a13fb93235b11bbda",
+          "size": 201839,
+          "filename": "attrs-21.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1672,7 +1688,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/e8/b0/cd2b968000577ec5ce6c741a54d846dfa402372369b8b6861720aa9ecea7/beautifulsoup4-4.11.1.tar.gz",
+          "sha256": "ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693",
+          "md5": "22f22f89cf9da41b22e1ece9639c66a3",
+          "size": 517113,
+          "filename": "beautifulsoup4-4.11.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1736,7 +1760,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ee/1f/b29c7371958ab41a800f8718f5d285bf4333b8d0b5a5a8650234463ee644/black-22.3.0.tar.gz",
+          "sha256": "35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
+          "md5": "1ae8332ebbdc492dcb53c9e8df2ec4f9",
+          "size": 554277,
+          "filename": "black-22.3.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1799,7 +1831,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6a/a3/217842324374fd3fb33db0eb4c2909ccf3ecc5a94f458088ac68581f8314/bleach-4.1.0.tar.gz",
+          "sha256": "0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da",
+          "md5": "41e70ac58aa7bc5ff96c8fef24b9d659",
+          "size": 195798,
+          "filename": "bleach-4.1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1859,7 +1899,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a2/d9/b6e56a303d221fc0bdff2c775e4eef7fedd58194aa5a96fa89fb71634cc9/boolean.py-4.0.tar.gz",
+          "sha256": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4",
+          "md5": "5a8b0eae254b0c37a1bdde38c6bd5b5d",
+          "size": 34504,
+          "filename": "boolean.py-4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1907,7 +1955,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/certifi/python-certifi.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -1919,7 +1967,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz",
+          "sha256": "9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
+          "md5": "70f3688480b8fc4556c033f3ea655d36",
+          "size": 156701,
+          "filename": "certifi-2022.5.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -1980,7 +2036,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz",
+          "sha256": "920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954",
+          "md5": "f3a3f26cd3335fc597479c9475da0a0b",
+          "size": 484058,
+          "filename": "cffi-1.15.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2055,7 +2119,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz",
+          "sha256": "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+          "md5": "f6664e0e90dbb3cc9cfc154a980f9864",
+          "size": 79105,
+          "filename": "charset-normalizer-2.0.12.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2104,7 +2176,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/click/issues/",
       "code_view_url": "https://github.com/pallets/click/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/click.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2116,7 +2188,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/dd/cf/706c1ad49ab26abed0b77a2f867984c1341ed7387b8030a6aa914e2942a0/click-8.0.4.tar.gz",
+          "sha256": "8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb",
+          "md5": "c89efc98d1b36d52ba26a39c803df0cc",
+          "size": 329520,
+          "filename": "click-8.0.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2189,7 +2269,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz",
+          "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+          "md5": "57b22f2597f63df051b69906fbf310cc",
+          "size": 27813,
+          "filename": "colorama-0.4.4.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2244,7 +2332,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/8b/65/99ad49681e8897ab851014f18bf51e8081a492efc1ef0b443209f7a83e0e/commoncode-30.2.0.tar.gz",
+          "sha256": "ee470359fc3833b6e87b40013b8a1bd5df973b56314bddb89ad1844ef1e835fd",
+          "md5": "754bc02c505adcf65a8d1006b7894703",
+          "size": 1690459,
+          "filename": "commoncode-30.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2301,7 +2397,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pyca/cryptography/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pyca/cryptography.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2314,7 +2410,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/51/05/bb2b681f6a77276fc423d04187c39dafdb65b799c8d87b62ca82659f9ead/cryptography-37.0.2.tar.gz",
+          "sha256": "f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e",
+          "md5": "7477bd10af69e78aed4c83accd401416",
+          "size": 585433,
+          "filename": "cryptography-37.0.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2419,7 +2523,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/57/b1/b880503681ea1b64df05106fc7e3c4e3801736cf63deffc6fa7fc5404cf5/docutils-0.18.1.tar.gz",
+          "sha256": "679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06",
+          "md5": "ca5827e2432fd58f4c8d74a6591135de",
+          "size": 2043249,
+          "filename": "docutils-0.18.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2479,7 +2591,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2d/a3/49cd39abdf8b4832cba27d635a775b721388e50671bee7ea0d10afcf0cfd/dparse2-0.6.1.tar.gz",
+          "sha256": "fbafb839c3dc83040012af2602a00ca4e4b1693a9b1988492150466afa59dd26",
+          "md5": "8d8c7be322b2211c5c5eea6150da2832",
+          "size": 10458,
+          "filename": "dparse2-0.6.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2538,7 +2658,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3d/5d/0413a31d184a20c763ad741cc7852a659bf15094c24840c5bdd1754765cd/et_xmlfile-1.1.0.tar.gz",
+          "sha256": "8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c",
+          "md5": "8fbae9b969eac28c02f5073febefc445",
+          "size": 3218,
+          "filename": "et_xmlfile-1.1.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2606,7 +2734,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7a/3c/b5ac9fc61e1e559ced3e40bf5b518a4142536b34eb274aa50dff29cb89f5/execnet-1.9.0.tar.gz",
+          "sha256": "8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5",
+          "md5": "69f7f721586d5a02b66cac7cb388b7e3",
+          "size": 173884,
+          "filename": "execnet-1.9.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2661,7 +2797,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/flask/issues/",
       "code_view_url": "https://github.com/pallets/flask/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/flask.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -2673,7 +2809,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "size": 631846,
+          "filename": "Flask-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2741,7 +2885,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz",
+          "sha256": "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
+          "md5": "5856306eac5f25db8249e37a4c6ee3e7",
+          "size": 286689,
+          "filename": "idna-3.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2794,7 +2946,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/85/ed/e65128cc5cb1580f22ee3009d9187ecdfcc43ffb3b581fe854b24e87d8e7/importlib_metadata-4.8.3.tar.gz",
+          "sha256": "766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668",
+          "md5": "833c41fd427678c8b590c5a7818dd873",
+          "size": 41979,
+          "filename": "importlib_metadata-4.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2854,7 +3014,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz",
+          "sha256": "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32",
+          "md5": "0b7f3be87481211c183eae095bcea6f1",
+          "size": 8104,
+          "filename": "iniconfig-1.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2912,7 +3080,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f8/80/81bf8129a2cc012a225ea0dc39cd6e11531a61d115616b1eead33b157164/intbitset-3.0.1.tar.gz",
+          "sha256": "f1e6d03c6729922a223c51849df65b9e916e625aefb911784e7f9acd4c207d53",
+          "md5": "8f417e4ec5879841fde7aa873320ffdc",
+          "size": 151831,
+          "filename": "intbitset-3.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -2983,7 +3159,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz",
+          "sha256": "e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
+          "md5": "717294d0a9017b27bd46b1c946b39bd0",
+          "size": 174062,
+          "filename": "isort-5.10.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3032,7 +3216,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/itsdangerous/issues/",
       "code_view_url": "https://github.com/pallets/itsdangerous/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/itsdangerous.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3044,7 +3228,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz",
+          "sha256": "5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a",
+          "md5": "c1bc730ddf53b8374eaa823f24eb6438",
+          "size": 56143,
+          "filename": "itsdangerous-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3095,7 +3287,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/09/0d/81744e179cf3aede2d117c20c6d5b97a62ffe16b2ca5d856e068e81c7a68/jeepney-0.7.1.tar.gz",
+          "sha256": "fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f",
+          "md5": "d804ad938b27d9b761f2c44f8d33fef6",
+          "size": 61833,
+          "filename": "jeepney-0.7.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3147,7 +3347,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/jinja/issues/",
       "code_view_url": "https://github.com/pallets/jinja/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/jinja.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3159,7 +3359,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz",
+          "sha256": "611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7",
+          "md5": "b76ae2f0647abebc81e7c03f5fb7b00f",
+          "size": 269196,
+          "filename": "Jinja2-3.0.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3220,7 +3428,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6f/23/143b4adec7d6957d35c0fc90c095203046da04eb5eade7fef8b00fe421fc/keyring-23.4.1.tar.gz",
+          "sha256": "89cbd74d4683ed164c8082fb38619341097741323b3786905c6dac04d6915a55",
+          "md5": "e1d85ffb9b2ba1032068c361e2431b3c",
+          "size": 54135,
+          "filename": "keyring-23.4.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3282,7 +3498,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/80/ad/9b3614c4630f3a1c0d5d7e5f6cfa8e90850186864e1181e86a65150d983f/license-expression-30.0.0.tar.gz",
+          "sha256": "ad638292aa8493f84354909b517922cb823582c2ce2c4d880e42544a86bea8dd",
+          "md5": "253c39f105199625d9ac35f0a50976e2",
+          "size": 158232,
+          "filename": "license-expression-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3334,7 +3558,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/markupsafe/issues/",
       "code_view_url": "https://github.com/pallets/markupsafe/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/markupsafe.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3346,7 +3570,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
+          "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+          "md5": "892e0fefa3c488387e5cc0cad2daa523",
+          "size": 18596,
+          "filename": "MarkupSafe-2.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3408,7 +3640,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz",
+          "sha256": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
+          "md5": "4163ff73d0db8631c0a78bb55b551c84",
+          "size": 4252,
+          "filename": "mypy_extensions-0.4.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3455,7 +3695,7 @@
       "sha512": null,
       "bug_tracking_url": "https://foss.heptapod.net/openpyxl/openpyxl/-/issues",
       "code_view_url": "https://foss.heptapod.net/openpyxl/openpyxl",
-      "vcs_url": null,
+      "vcs_url": "https://foss.heptapod.net/openpyxl/openpyxl.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -3467,7 +3707,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/2c/b8/ff77a718173fd73e49f883b4fda88f11af1fc51edb9252af3785b0cad987/openpyxl-3.0.10.tar.gz",
+          "sha256": "e47805627aebcf860edb4edf7987b1309c1b3632f3750538ed962bbcc3bd7449",
+          "md5": "ebcc3a30768a45163d5143f1f7bf0224",
+          "size": 179688,
+          "filename": "openpyxl-3.0.10.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3532,7 +3780,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/6e/ee/8d89d660da6e44d77f547de9949b380dc93b08b758ee361bc237bcc8b179/packageurl-python-0.9.9.tar.gz",
+          "sha256": "872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09",
+          "md5": "35651efef038a54f5083197038d358c0",
+          "size": 30107,
+          "filename": "packageurl-python-0.9.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3595,7 +3851,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz",
+          "sha256": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+          "md5": "e713c1939f294fd729af4a7be40dd141",
+          "size": 84848,
+          "filename": "packaging-21.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3661,7 +3925,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f6/33/436c5cb94e9f8902e59d1d544eb298b83c84b9ec37b5b769c5a0ad6edb19/pathspec-0.9.0.tar.gz",
+          "sha256": "e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
+          "md5": "9b6b70fa5ffc31e6f5700522880140c0",
+          "size": 29483,
+          "filename": "pathspec-0.9.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3715,7 +3987,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fc/aa/4fbc8040db7afae616eda6329ddc8ef73afc8bcb611bf9126937970bca83/pip-requirements-parser-31.2.0.tar.gz",
+          "sha256": "8c2a6f8e091ac2693824a5ef4e3b250226e34f74a20a91a87b9ab0714b47788f",
+          "md5": "a202d8dda5f2840181b80d4c81fa63d0",
+          "size": 209659,
+          "filename": "pip-requirements-parser-31.2.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3766,14 +4046,22 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pypa/pip",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pypa/pip.git",
       "copyright": null,
       "license_expression": "MIT",
       "declared_license": {},
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz",
+          "sha256": "d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78",
+          "md5": "45e150b98c9147351ee4252afe7e6c60",
+          "size": 1840400,
+          "filename": "pip-26.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3833,7 +4121,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/9e/c0/2ca9cb24d8045a1c84bdeca2b2646fcf438266a930301a7672c4cb8d0ff9/pipdeptree-2.2.1.tar.gz",
+          "sha256": "2b97d80c64d229e01ad242f14229a899263c6e8645c588ec5b054c1b81f3065d",
+          "md5": "05cab13fbae0ebb7015a6ce6757000e7",
+          "size": 22430,
+          "filename": "pipdeptree-2.2.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3895,7 +4191,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/90/8d/09cc1c99a30ac14050fc4e04e549e024be83ff72a7f63e75023501baf977/pkginfo2-30.0.0.tar.gz",
+          "sha256": "5e1afbeb156febb407a9b5c16b51c5b4737c529eeda2b1607e1e277cf260669c",
+          "md5": "8fd5bd0d69938534c9796195164b5928",
+          "size": 364071,
+          "filename": "pkginfo2-30.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -3958,7 +4262,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/00/91/fe0806e3ebded8c4e52f93ab4d963eef34bb33595c7aa7b5591d32ab5b92/pkginfo-1.8.3.tar.gz",
+          "sha256": "a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c",
+          "md5": "e67d8f6e37ca37b5512384655bbce760",
+          "size": 375734,
+          "filename": "pkginfo-1.8.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4011,7 +4323,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/platformdirs/platformdirs/issues",
       "code_view_url": "https://github.com/platformdirs/platformdirs",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/platformdirs/platformdirs.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4023,7 +4335,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/4b/96/d70b9462671fbeaacba4639ff866fb4e9e558580853fc5d6e698d0371ad4/platformdirs-2.4.0.tar.gz",
+          "sha256": "367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+          "md5": "4e5b836d19600cc4bf0b789ab1de3b51",
+          "size": 24051,
+          "filename": "platformdirs-2.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4089,7 +4409,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz",
+          "sha256": "4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+          "md5": "daa6fddfb6cd364f3c82e52098911e4b",
+          "size": 51510,
+          "filename": "pluggy-1.0.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4159,7 +4487,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz",
+          "sha256": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+          "md5": "bde7dcc1cb452a1e10206ef2f811ba88",
+          "size": 207796,
+          "filename": "py-1.11.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4236,7 +4572,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/08/dc/b29daf0a202b03f57c19e7295b60d1d5e1281c45a6f5f573e41830819918/pycodestyle-2.8.0.tar.gz",
+          "sha256": "eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f",
+          "md5": "7f4f7cc6634e9388a8bbd35f92e66a6b",
+          "size": 102299,
+          "filename": "pycodestyle-2.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4297,7 +4641,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz",
+          "sha256": "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206",
+          "md5": "48f7d743bf018f7bb2ffc5fb976d1492",
+          "size": 170877,
+          "filename": "pycparser-2.21.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4352,7 +4704,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pygments/pygments/issues",
       "code_view_url": "https://github.com/pygments/pygments",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pygments/pygments.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4364,7 +4716,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz",
+          "sha256": "5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+          "md5": "2137c19d9ac0cc556badc89e746c0e62",
+          "size": 4282017,
+          "filename": "Pygments-2.12.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4428,7 +4788,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz",
+          "sha256": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+          "md5": "fadc2f3bf5872bf6310576a86c3566e0",
+          "size": 1999906,
+          "filename": "pyparsing-3.0.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4494,7 +4862,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f1/bc/0121a2e386b261b69f4f5aa48e5304c947451dce70d68628cb28d5cd0d28/pytest-forked-1.4.0.tar.gz",
+          "sha256": "8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e",
+          "md5": "fc2d4bb78f3a5e7c082173527d5009d3",
+          "size": 10197,
+          "filename": "pytest-forked-1.4.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4561,7 +4937,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/5d/43/9dbc32d297d6eae85d6c05dc8e8d3371061bd6cbe56a2f645d9ea4b53d9b/pytest-xdist-2.5.0.tar.gz",
+          "sha256": "4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf",
+          "md5": "aaec318fa6e83d99bd366d3ef45252da",
+          "size": 72455,
+          "filename": "pytest-xdist-2.5.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4616,7 +5000,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pytest-dev/pytest/issues",
       "code_view_url": "https://github.com/pytest-dev/pytest",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pytest-dev/pytest.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4628,7 +5012,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3e/2c/a67ad48759051c7abf82ce182a4e6d766de371b183182d2dde03089e8dfb/pytest-7.0.1.tar.gz",
+          "sha256": "e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171",
+          "md5": "995d64fe44bbe717d03bd703d5c48ec6",
+          "size": 1249154,
+          "filename": "pytest-7.0.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4681,7 +5073,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/yaml/pyyaml/issues",
       "code_view_url": "https://github.com/yaml/pyyaml",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/yaml/pyyaml.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4693,7 +5085,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+          "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+          "md5": "1d19c798f25e58e3e582f0f8c977dbb8",
+          "size": 124996,
+          "filename": "PyYAML-6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4760,7 +5160,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/52/c5/6c090aad067a6f05681367fc33ab2c8d571a3739405bec60f7ba486e83de/readme_renderer-34.0.tar.gz",
+          "sha256": "dfb4d17f21706d145f7473e0b61ca245ba58e810cf9b2209a48239677f82e5b0",
+          "md5": "a7e83bdafe0e71b6d4786566de7430fd",
+          "size": 28835,
+          "filename": "readme_renderer-34.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4820,7 +5228,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/28/30/7bf7e5071081f761766d46820e52f4b16c8a08fef02d2eb4682ca7534310/requests-toolbelt-0.9.1.tar.gz",
+          "sha256": "968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0",
+          "md5": "b1509735c4b4cf95df2619facbc3672e",
+          "size": 207286,
+          "filename": "requests-toolbelt-0.9.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4876,7 +5292,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/psf/requests",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/psf/requests.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -4888,7 +5304,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz",
+          "sha256": "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+          "md5": "bcc01b73974a305cc7c5b092e7d07004",
+          "size": 106758,
+          "filename": "requests-2.27.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -4946,7 +5370,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ac/20/9541749d77aebf66dd92e2b803f38a50e3a5c76e7876f45eb2b37e758d82/resolvelib-0.8.1.tar.gz",
+          "sha256": "c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+          "md5": "fbd5fbcac181644333390ea6a71c4edc",
+          "size": 17308,
+          "filename": "resolvelib-0.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5006,7 +5438,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz",
+          "sha256": "270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
+          "md5": "0e3a03c3eb3b679d5a253b168bb5774a",
+          "size": 49378,
+          "filename": "rfc3986-1.5.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5060,7 +5500,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/4a/7374cac103bdfec7c199606784119bee9171ba051290b219ffec1bedc650/saneyaml-0.5.2.tar.gz",
+          "sha256": "d6074f1959041342ab41d74a6f904720ffbcf63c94467858e0e22e17e3c43d41",
+          "md5": "4985d7a8f4ad5af6ae53132e8d23a247",
+          "size": 32034,
+          "filename": "saneyaml-0.5.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5121,7 +5569,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/bc/3b/6e294fcaa5aed4059f2aa01a1ee7d343953521f8e0f6965ebcf63c950269/SecretStorage-3.3.2.tar.gz",
+          "sha256": "0a8eb9645b320881c222e827c26f4cfcf55363e8b374a021981ef886657a912f",
+          "md5": "4de3603efceaeba6194a833c32365812",
+          "size": 19285,
+          "filename": "SecretStorage-3.3.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5177,7 +5633,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz",
+          "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+          "md5": "a7c927740e4964dd29b72cebfc1429bb",
+          "size": 34041,
+          "filename": "six-1.16.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5245,7 +5709,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/f3/03/bac179d539362319b4779a00764e95f7542f4920084163db6b0fd4742d38/soupsieve-2.3.2.post1.tar.gz",
+          "sha256": "fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d",
+          "md5": "4c824620563604cbf783de149c8b8889",
+          "size": 102814,
+          "filename": "soupsieve-2.3.2.post1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5311,7 +5783,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz",
+          "sha256": "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93",
+          "md5": "53a0a6c5aef8f5eb5834e78e0fdf0499",
+          "size": 76885,
+          "filename": "text-unidecode-1.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5378,7 +5858,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+          "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+          "md5": "59bce5d8d67e858735ec3f399ec90253",
+          "size": 22253,
+          "filename": "toml-0.10.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5441,7 +5929,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/fb/2e/d0a8276b0cf9b9e34fd0660c330acc59656f53bb2209adc75af863a3582d/tomli-1.2.3.tar.gz",
+          "sha256": "05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
+          "md5": "807cc80e6a2697375f431b757994b7c5",
+          "size": 15094,
+          "filename": "tomli-1.2.3.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5543,7 +6039,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/tqdm/tqdm",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/tqdm/tqdm.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5556,7 +6052,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/98/2a/838de32e09bd511cf69fe4ae13ffc748ac143449bfc24bb3fd172d53a84f/tqdm-4.64.0.tar.gz",
+          "sha256": "40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
+          "md5": "231212e145ac51214286b310704447d4",
+          "size": 169499,
+          "filename": "tqdm-4.64.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5610,7 +6114,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/pypa/twine/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pypa/twine.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5621,7 +6125,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/d1/3e/ce331d7e215abdc16c53e65f8506bfccf4840ce191b709a37b8c83cc32c7/twine-3.8.0.tar.gz",
+          "sha256": "8efa52658e0ae770686a13b675569328f1fba9837e5de1867bfe5f46a9aefe19",
+          "md5": "7f904fed5983ea072e1b229486ba4647",
+          "size": 214568,
+          "filename": "twine-3.8.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5694,7 +6206,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/b1/5a/8b5fbb891ef3f81fc923bf3cb4a578c0abf9471eb50ce0f51c74212182ab/typing_extensions-4.1.1.tar.gz",
+          "sha256": "1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+          "md5": "3cd9b7b9a465afbcca8548e11668ca64",
+          "size": 26694,
+          "filename": "typing_extensions-4.1.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5751,7 +6271,7 @@
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/urllib3/urllib3",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/urllib3/urllib3.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5763,7 +6283,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/1b/a5/4eab74853625505725cefdf168f48661b2cd04e7843ab836f3f63abf81da/urllib3-1.26.9.tar.gz",
+          "sha256": "aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e",
+          "md5": "d4b58522821a33c5e421191b83e0dbac",
+          "size": 295258,
+          "filename": "urllib3-1.26.9.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5827,7 +6355,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz",
+          "sha256": "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923",
+          "md5": "32f6e261d52e57bf7e1c4d41546d15b8",
+          "size": 9721,
+          "filename": "webencodings-0.5.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5882,7 +6418,7 @@
       "sha512": null,
       "bug_tracking_url": "https://github.com/pallets/werkzeug/issues/",
       "code_view_url": "https://github.com/pallets/werkzeug/",
-      "vcs_url": null,
+      "vcs_url": "https://github.com/pallets/werkzeug.git",
       "copyright": null,
       "license_expression": null,
       "declared_license": {
@@ -5894,7 +6430,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/10/cf/97eb1a3847c01ae53e8376bc21145555ac95279523a935963dc8ff96c50b/Werkzeug-2.1.2.tar.gz",
+          "sha256": "1ce08e8093ed67d638d63879fd1ba3735817f7a80de3674d293f5984f25fb6e6",
+          "md5": "5835c8738b8081c53367cbcc5db8784c",
+          "size": 835169,
+          "filename": "Werkzeug-2.1.2.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
@@ -5947,7 +6491,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/02/bf/0d03dbdedb83afec081fefe86cae3a2447250ef1a81ac601a9a56e785401/zipp-3.6.0.tar.gz",
+          "sha256": "71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+          "md5": "8d5cf6eb3270384ae13a6440797ea564",
+          "size": 13047,
+          "filename": "zipp-3.6.0.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/tilde_req-expected-env.json
+++ b/tests/data/tilde_req-expected-env.json
@@ -25,7 +25,7 @@
       "subpath": null,
       "primary_language": "Python",
       "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: `PyPI link`_\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n   :target: `PyPI link`_\n\n.. _PyPI link: https://pypi.org/project/zipp\n\n.. image:: https://github.com/jaraco/zipp/workflows/tests/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/badge/code%20style-black-000000.svg\n   :target: https://github.com/psf/black\n   :alt: Code style: Black\n\n.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest\n..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2022-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.5\n     - 3.11\n   * - 3.3\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.\n\nSecurity Contact\n================\n\nTo report a security vulnerability, please use the\n`Tidelift security contact <https://tidelift.com/security>`_.\nTidelift will coordinate the fix and disclosure.",
-      "release_date": "2022-07-12T14:21:21",
+      "release_date": "2022-07-12T14:21:20",
       "parties": [
         {
           "type": "person",
@@ -42,11 +42,11 @@
         "Programming Language :: Python :: 3 :: Only"
       ],
       "homepage_url": "https://github.com/jaraco/zipp",
-      "download_url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
-      "size": 14189,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/zipp-3.8.1-py3-none-any.whl",
+      "size": 5645,
       "sha1": null,
-      "md5": "6f15c3e3c78919f8936749b0033e0cea",
-      "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+      "md5": "300aa262796e7ebfb57b4d6731821c29",
+      "sha256": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": null,
@@ -61,7 +61,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
+          "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+          "md5": "6f15c3e3c78919f8936749b0033e0cea",
+          "size": 14189,
+          "filename": "zipp-3.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/tilde_req-expected-max-rounds.json
+++ b/tests/data/tilde_req-expected-max-rounds.json
@@ -25,7 +25,7 @@
       "subpath": null,
       "primary_language": "Python",
       "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: `PyPI link`_\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n   :target: `PyPI link`_\n\n.. _PyPI link: https://pypi.org/project/zipp\n\n.. image:: https://github.com/jaraco/zipp/workflows/tests/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/badge/code%20style-black-000000.svg\n   :target: https://github.com/psf/black\n   :alt: Code style: Black\n\n.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest\n..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2022-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.5\n     - 3.11\n   * - 3.3\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.\n\nSecurity Contact\n================\n\nTo report a security vulnerability, please use the\n`Tidelift security contact <https://tidelift.com/security>`_.\nTidelift will coordinate the fix and disclosure.",
-      "release_date": "2022-07-12T14:21:21",
+      "release_date": "2022-07-12T14:21:20",
       "parties": [
         {
           "type": "person",
@@ -42,11 +42,11 @@
         "Programming Language :: Python :: 3 :: Only"
       ],
       "homepage_url": "https://github.com/jaraco/zipp",
-      "download_url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
-      "size": 14189,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/zipp-3.8.1-py3-none-any.whl",
+      "size": 5645,
       "sha1": null,
-      "md5": "6f15c3e3c78919f8936749b0033e0cea",
-      "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+      "md5": "300aa262796e7ebfb57b4d6731821c29",
+      "sha256": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": null,
@@ -61,7 +61,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
+          "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+          "md5": "6f15c3e3c78919f8936749b0033e0cea",
+          "size": 14189,
+          "filename": "zipp-3.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/tilde_req-expected-netrc.json
+++ b/tests/data/tilde_req-expected-netrc.json
@@ -25,7 +25,7 @@
       "subpath": null,
       "primary_language": "Python",
       "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: `PyPI link`_\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n   :target: `PyPI link`_\n\n.. _PyPI link: https://pypi.org/project/zipp\n\n.. image:: https://github.com/jaraco/zipp/workflows/tests/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/badge/code%20style-black-000000.svg\n   :target: https://github.com/psf/black\n   :alt: Code style: Black\n\n.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest\n..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2022-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.5\n     - 3.11\n   * - 3.3\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.\n\nSecurity Contact\n================\n\nTo report a security vulnerability, please use the\n`Tidelift security contact <https://tidelift.com/security>`_.\nTidelift will coordinate the fix and disclosure.",
-      "release_date": "2022-07-12T14:21:21",
+      "release_date": "2022-07-12T14:21:20",
       "parties": [
         {
           "type": "person",
@@ -42,11 +42,11 @@
         "Programming Language :: Python :: 3 :: Only"
       ],
       "homepage_url": "https://github.com/jaraco/zipp",
-      "download_url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
-      "size": 14189,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/zipp-3.8.1-py3-none-any.whl",
+      "size": 5645,
       "sha1": null,
-      "md5": "6f15c3e3c78919f8936749b0033e0cea",
-      "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+      "md5": "300aa262796e7ebfb57b4d6731821c29",
+      "sha256": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": null,
@@ -61,7 +61,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
+          "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+          "md5": "6f15c3e3c78919f8936749b0033e0cea",
+          "size": 14189,
+          "filename": "zipp-3.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/data/tilde_req-expected.json
+++ b/tests/data/tilde_req-expected.json
@@ -25,7 +25,7 @@
       "subpath": null,
       "primary_language": "Python",
       "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: `PyPI link`_\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n   :target: `PyPI link`_\n\n.. _PyPI link: https://pypi.org/project/zipp\n\n.. image:: https://github.com/jaraco/zipp/workflows/tests/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/badge/code%20style-black-000000.svg\n   :target: https://github.com/psf/black\n   :alt: Code style: Black\n\n.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest\n..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2022-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.5\n     - 3.11\n   * - 3.3\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.\n\nSecurity Contact\n================\n\nTo report a security vulnerability, please use the\n`Tidelift security contact <https://tidelift.com/security>`_.\nTidelift will coordinate the fix and disclosure.",
-      "release_date": "2022-07-12T14:21:21",
+      "release_date": "2022-07-12T14:21:20",
       "parties": [
         {
           "type": "person",
@@ -42,11 +42,11 @@
         "Programming Language :: Python :: 3 :: Only"
       ],
       "homepage_url": "https://github.com/jaraco/zipp",
-      "download_url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
-      "size": 14189,
+      "download_url": "https://thirdparty.aboutcode.org/pypi/zipp-3.8.1-py3-none-any.whl",
+      "size": 5645,
       "sha1": null,
-      "md5": "6f15c3e3c78919f8936749b0033e0cea",
-      "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+      "md5": "300aa262796e7ebfb57b4d6731821c29",
+      "sha256": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": null,
@@ -61,7 +61,15 @@
       "notice_text": null,
       "source_packages": [],
       "file_references": [],
-      "extra_data": {},
+      "extra_data": {
+        "source_artifact": {
+          "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
+          "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+          "md5": "6f15c3e3c78919f8936749b0033e0cea",
+          "size": 14189,
+          "filename": "zipp-3.8.1.tar.gz"
+        }
+      },
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/aboutcode-org/python-inspector for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+from python_inspector.package_data import get_pypi_codeview_url
+from python_inspector.package_data import get_sdist_from_urls
+
+
+def test_get_pypi_codeview_url():
+    assert (
+        get_pypi_codeview_url({"Source": "https://github.com/psf/requests"})
+        == "https://github.com/psf/requests"
+    )
+    assert (
+        get_pypi_codeview_url({"Code": "https://github.com/psf/requests"})
+        == "https://github.com/psf/requests"
+    )
+    assert (
+        get_pypi_codeview_url({"Source Code": "https://github.com/psf/requests"})
+        == "https://github.com/psf/requests"
+    )
+    assert get_pypi_codeview_url({}) is None
+
+
+def test_get_sdist_from_urls():
+    urls = [
+        {"packagetype": "bdist_wheel", "url": "https://example.com/pkg-1.0.whl"},
+        {
+            "packagetype": "sdist",
+            "url": "https://example.com/pkg-1.0.tar.gz",
+            "digests": {"sha256": "abc123", "md5": "def456"},
+            "size": 12345,
+            "filename": "pkg-1.0.tar.gz",
+        },
+    ]
+    result = get_sdist_from_urls(urls)
+    assert result["url"] == "https://example.com/pkg-1.0.tar.gz"
+    assert result["sha256"] == "abc123"
+    assert result["filename"] == "pkg-1.0.tar.gz"
+
+
+def test_get_sdist_from_urls_returns_none_when_missing():
+    assert get_sdist_from_urls([]) is None
+    assert get_sdist_from_urls(None) is None
+    assert get_sdist_from_urls([{"packagetype": "bdist_wheel"}]) is None
+
+
+def test_get_sdist_from_urls_md5_digest_fallback():
+    urls = [{"packagetype": "sdist", "url": "x", "md5_digest": "old", "digests": {}}]
+    assert get_sdist_from_urls(urls)["md5"] == "old"


### PR DESCRIPTION
When using `--index-url` with a custom Artifactory repository, dependency resolution works but the `packages` array comes back empty. This happens because `get_pypi_data_from_purl()` hardcodes `https://pypi.org/pypi` for the JSON API endpoint. Internal packages that don't exist on PyPI.org return 404 and are silently skipped.


The fix includes deriving the JSON API base URL from the provided repository instead of hardcoding PyPI.org
It is also necessary to match distribution files by filename (standardized per PEP 427/491) instead of full URL, since URL paths can differ between Simple API and JSON API endpoints.